### PR TITLE
Drone CI: Move testing logic to separate pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,12 +5,21 @@ steps:
   - name: version
     image: alpine:3.8
     commands:
-      - apk add git
+      - apk add --no-cache git
       - git fetch --tags
       - git describe
       - git describe > SEED
       - echo -n $(git describe),latest > .tags
-  - name: build
+  - name: test
+    image: alpine:3.8
+    commands:
+      - apk add --no-cache openjdk8 python curl nodejs
+      - curl -L https://github.com/scalacenter/bloop/releases/download/v$(cat BLOOP)/install.py | python - -d bloop
+      - export PATH=$(pwd)/bloop:$PATH
+      - blp-server &
+      - ./build.sh
+      - ./csbt test
+  - name: publish
     image: plugins/docker
     environment:
       BINTRAY_USERNAME:
@@ -26,10 +35,15 @@ steps:
       build_args_from_env:
         - BINTRAY_USERNAME
         - BINTRAY_API
-    trigger:
+    when:
+      branch:
+        - master
       event:
-        - push
-        - tag
+        include:
+          - push
+          - tag
+        exclude:
+          - pull_request
   - name: benchmarks
     image: tindzk/seed:latest
     pull: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ FROM alpine:3.8 as build
 ARG BINTRAY_USERNAME
 ARG BINTRAY_API
 
-RUN apk add --no-cache openjdk8 python curl nodejs
+RUN apk add --no-cache openjdk8 python curl
 
 ENV LANG       C.UTF-8
 ENV JAVA_HOME  /usr/lib/jvm/java-1.8-openjdk
 ENV PATH       $PATH:$JAVA_HOME/jre/bin:$JAVA_HOME/bin:/seed/bloop
 
-COPY build.sbt BLOOP SEED COURSIER  /seed/
+COPY build.sh build.sbt BLOOP SEED COURSIER  /seed/
 COPY project/  /seed/project/
 COPY src/      /seed/src/
 
@@ -33,34 +33,7 @@ RUN blp-coursier fetch \
     ch.epfl.scala:bloop-native-bridge_2.12:$(cat BLOOP)
 
 RUN set -x && \
-    (blp-server &) && \
-    curl -o csbt https://raw.githubusercontent.com/coursier/sbt-launcher/master/csbt && \
-    chmod +x csbt && \
-    (./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile || \
-     ./csbt compile \
-    ) && \
-    ./csbt test && \
+    ./build.sh && \
     BINTRAY_USER=$BINTRAY_USERNAME BINTRAY_PASS=$BINTRAY_API ./csbt --add-coursier=true "; publishLocal; publish"
 
 RUN blp-coursier bootstrap tindzk:seed_2.12:$(cat SEED) -f -o seed

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -x
+curl -o csbt https://raw.githubusercontent.com/coursier/sbt-launcher/master/csbt
+chmod +x csbt
+./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile || \
+	 ./csbt compile


### PR DESCRIPTION
Only publish artefacts for the `master` branch, while continuing to test builds from development branches.

Exclude pull requests from the `publish` pipeline.

Also factor out csbt commands from Dockerfile into a separate file for better reuse.