### PR TITLE
Idea: Fix path normalisation

### DIFF
--- a/src/main/scala/seed/cli/Build.scala
+++ b/src/main/scala/seed/cli/Build.scala
@@ -36,7 +36,7 @@ object Build {
     val tmpfs = command.packageConfig.tmpfs || seedConfig.build.tmpfs
     if (isBloop) Bloop.build(projectPath, build, platformResolution,
       compilerResolution, tmpfs)
-    if (isIdea) Idea.build(projectPath, build, platformResolution,
+    if (isIdea) Idea.build(projectPath, projectPath, build, platformResolution,
       compilerResolution, tmpfs)
   }
 }

--- a/src/main/scala/seed/config/BuildConfig.scala
+++ b/src/main/scala/seed/config/BuildConfig.scala
@@ -20,8 +20,13 @@ object BuildConfig {
       sys.exit(1)
     }
 
+    def parentOf(path: Path): Path = {
+      val p = path.getParent
+      if (p != null) p else path.toAbsolutePath.getParent
+    }
+
     val (projectPath, projectFile) =
-      if (Files.isRegularFile(path)) (path.toAbsolutePath.getParent, path)
+      if (Files.isRegularFile(path)) (parentOf(path), path)
       else (path, path.resolve("build.toml"))
 
     Log.info(s"Loading project ${Ansi.italic(projectFile.toString)}...")

--- a/src/test/scala/seed/config/BuildConfigSpec.scala
+++ b/src/test/scala/seed/config/BuildConfigSpec.scala
@@ -1,0 +1,38 @@
+package seed.config
+
+import java.io.File
+
+import minitest.SimpleTestSuite
+import java.nio.file.Paths
+
+import org.apache.commons.io.FileUtils
+
+object BuildConfigSpec extends SimpleTestSuite {
+  test("Resolve absolute project path") {
+    FileUtils.write(new File("/tmp/a.toml"),
+      """
+        |[project]
+        |scalaVersion = "2.12.8"
+        |
+        |[module.example.jvm]
+        |sources = ["src"]
+      """.stripMargin, "UTF-8")
+
+    val (projectPath, _) = BuildConfig.load(Paths.get("/tmp/a.toml"))
+    assertEquals(projectPath, Paths.get("/tmp"))
+  }
+
+  test("Resolve relative project path") {
+    FileUtils.write(new File("test/a.toml"),
+      """
+        |[project]
+        |scalaVersion = "2.12.8"
+        |
+        |[module.example.jvm]
+        |sources = ["src"]
+      """.stripMargin, "UTF-8")
+
+    val (projectPath, _) = BuildConfig.load(Paths.get("test/a.toml"))
+    assertEquals(projectPath, Paths.get("test"))
+  }
+}

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -1,0 +1,56 @@
+package seed.generation
+
+import minitest.SimpleTestSuite
+
+import java.nio.file.Paths
+
+import seed.Cli.PackageConfig
+import seed.artefact.ArtefactResolution
+import seed.model.Build.{Module, Project}
+import seed.model.Platform.JVM
+import seed.model.Build
+
+object IdeaSpec extends SimpleTestSuite {
+  test("Normalise paths") {
+    assertEquals(
+      Idea.normalisePath(Idea.ModuleDir, Paths.get("/tmp"))(Paths.get("/tmp")),
+      "$MODULE_DIR$/")
+
+    assertEquals(
+      Idea.normalisePath(Idea.ModuleDir, Paths.get("/tmp/.idea/modules"))(
+        Paths.get("/tmp/src")
+      ), "$MODULE_DIR$/../../src")
+
+    assertEquals(
+      Idea.normalisePath(Idea.ModuleDir, Paths.get(".idea/modules"))(Paths.get("/tmp/build")),
+      "/tmp/build")
+  }
+
+  test("Generate modules") {
+    val build =
+      Build(
+        project = Project("2.12.8"),
+        module = Map(
+          "a" -> Module(
+            targets = List(JVM),
+            jvm = Some(Module(
+              root = Some(Paths.get("a")),
+              sources = List(Paths.get("a/src"))))),
+          "b" -> Module(
+            targets = List(JVM),
+            jvm = Some(Module(
+              root = Some(Paths.get("b")),
+              sources = List(Paths.get("b/src")))))))
+
+    val projectPath = Paths.get(".")
+    val outputPath = Paths.get("/tmp")
+    val packageConfig = PackageConfig(false, false, None, None)
+    val compilerDeps = ArtefactResolution.allCompilerDeps(build)
+    val (_, platformResolution, compilerResolution) =
+      ArtefactResolution.resolution(seed.model.Config(), build, packageConfig,
+        optionalArtefacts = false, Set(), compilerDeps)
+
+    Idea.build(projectPath, outputPath, build, platformResolution,
+      compilerResolution, false)
+  }
+}


### PR DESCRIPTION
When a build file imported external modules, the `idea` command could fail with an exception thrown by `relativize()`. This commit addresses various corner cases and consolidates the logic for path normalisation.

Also, `BuildConfig` was changed to prefer a relative build project path as this value gets propagated to the generators.

The new tests could result in multiple dependency resolutions being triggered at the same time if artefacts were not cached locally. This was causing Drone CI builds to fail. Avoid concurrent access during dependency resolution by using a re-entrant lock.

Finally, make sure that the logger is only initialised once.