### PR TITLE
Idea: Fix dependency resolution of platform dependencies

### DIFF
--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -153,8 +153,8 @@ object Idea {
               collectJsDeps(build, module).map(dep =>
                 ArtefactResolution.dependencyFromDep(
                   dep, JavaScript,
-                  build.project.scalaVersion,
-                  build.project.scalaJsVersion.get)
+                  build.project.scalaJsVersion.get,
+                  build.project.scalaVersion)
               ).toSet,
               optionalArtefacts = true),
             resolvedTestDeps = module.test.toList.flatMap(test =>
@@ -162,8 +162,8 @@ object Idea {
                 collectJsDeps(build, test).map(dep =>
                   ArtefactResolution.dependencyFromDep(
                     dep, JavaScript,
-                    build.project.scalaVersion,
-                    build.project.scalaJsVersion.get)
+                    build.project.scalaJsVersion.get,
+                    build.project.scalaVersion)
                 ).toSet,
                 optionalArtefacts = true)),
             moduleDeps =
@@ -257,8 +257,8 @@ object Idea {
               collectNativeDeps(build, module).map(dep =>
                 ArtefactResolution.dependencyFromDep(
                   dep, Native,
-                  build.project.scalaVersion,
-                  build.project.scalaNativeVersion.get)
+                  build.project.scalaNativeVersion.get,
+                  build.project.scalaVersion)
               ).toSet,
               optionalArtefacts = true),
             resolvedTestDeps = module.test.toList.flatMap(test =>
@@ -266,8 +266,8 @@ object Idea {
                 collectNativeDeps(build, test).map(dep =>
                   ArtefactResolution.dependencyFromDep(
                     dep, Native,
-                    build.project.scalaVersion,
-                    build.project.scalaNativeVersion.get)
+                    build.project.scalaNativeVersion.get,
+                    build.project.scalaVersion)
                 ).toSet,
                 optionalArtefacts = true)),
             moduleDeps =

--- a/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
+++ b/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
@@ -1,0 +1,15 @@
+package seed.artefact
+
+import minitest.SimpleTestSuite
+import seed.model.Build.Dep
+import seed.model.Platform.JavaScript
+
+object ArtefactResolutionSpec extends SimpleTestSuite {
+  test("dependencyFromDep()") {
+    val scalaDep = Dep("org.scala-js", "scalajs-dom", "0.9.6")
+    val javaDep = ArtefactResolution.dependencyFromDep(
+      scalaDep, JavaScript, "0.6", "2.12")
+    assertEquals(javaDep,
+      Dep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6"))
+  }
+}

--- a/src/test/scala/seed/artefact/CoursierSpec.scala
+++ b/src/test/scala/seed/artefact/CoursierSpec.scala
@@ -1,0 +1,20 @@
+package seed.artefact
+
+import minitest.SimpleTestSuite
+import seed.model.Build
+import seed.model.Build.Dep
+
+object CoursierSpec extends SimpleTestSuite {
+  test("Resolve dependency") {
+    val dep = Dep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6")
+    val resolution = Coursier.resolveAndDownload(Set(dep),
+      Build.Resolvers(), Coursier.DefaultIvyPath,
+      Coursier.DefaultCachePath, optionalArtefacts = true)
+
+    val result =
+      Coursier.localArtefacts(resolution, Set(dep), optionalArtefacts = true)
+    assert(
+      result.exists(_.javaDocJar.nonEmpty) &&
+      result.exists(_.sourcesJar.nonEmpty))
+  }
+}


### PR DESCRIPTION
JavaScript and native dependencies were ignored because the two parameters `platformVersion` and `compilerVersion` had been mixed up.

Add a `require()` to `resolveSubset()` in order to enforce that a valid set of dependencies is passed.