### PR TITLE
Inherit target platforms on test modules

### DIFF
--- a/src/main/scala/seed/artefact/ArtefactResolution.scala
+++ b/src/main/scala/seed/artefact/ArtefactResolution.scala
@@ -169,8 +169,9 @@ object ArtefactResolution {
                   module: Module,
                   platforms: Set[Platform],
                   parent: Module = Module()
-                 ): Set[Dep] =
-    module.targets.toSet[Platform].intersect(platforms).flatMap { target =>
+                 ): Set[Dep] = {
+    val targets = if (module.targets.isEmpty) parent.targets else module.targets
+    targets.toSet[Platform].intersect(platforms).flatMap { target =>
       // Shared libraries
       if (target == JVM)
         jvmDeps(build,
@@ -194,6 +195,7 @@ object ArtefactResolution {
        List(native, parent.native.getOrElse(Module()), module)))
     ) ++
     module.test.toSet.flatMap(libraryDeps(build, _, platforms, module))
+  }
 
   def libraryArtefacts(build: Build,
                        module: Module,

--- a/src/main/scala/seed/artefact/Coursier.scala
+++ b/src/main/scala/seed/artefact/Coursier.scala
@@ -142,9 +142,10 @@ object Coursier {
               sources = optionalArtefacts,
               javaDoc = optionalArtefacts)))
 
-    require(deps.forall(d => result.map(_._1.module).exists(m =>
+    val missing = deps.filter(d => !result.map(_._1.module).exists(m =>
       m.organization.value == d.organisation &&
-      m.name.value == d.artefact)), "Missing dependencies in artefact resolution")
+      m.name.value == d.artefact))
+    require(missing.isEmpty, s"Missing dependencies in artefact resolution: $missing")
 
     result.map(a => (a._2.classifier, a._3)).toList
   }

--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 import seed.artefact.MavenCentral
 
-case class Build(`import`: List[String] = List(),
+case class Build(`import`: List[Path] = List(),
                  project: Build.Project,
                  resolvers: Build.Resolvers = Build.Resolvers(),
                  module: Map[String, Build.Module])

--- a/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
+++ b/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
@@ -1,8 +1,13 @@
 package seed.artefact
 
+import java.nio.file.Paths
+
 import minitest.SimpleTestSuite
 import seed.model.Build.Dep
 import seed.model.Platform.JavaScript
+import seed.model.Build.{Module, Project}
+import seed.model.Platform.JVM
+import seed.model.Build
 
 object ArtefactResolutionSpec extends SimpleTestSuite {
   test("dependencyFromDep()") {
@@ -11,5 +16,22 @@ object ArtefactResolutionSpec extends SimpleTestSuite {
       scalaDep, JavaScript, "0.6", "2.12")
     assertEquals(javaDep,
       Dep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6"))
+  }
+
+  test("Extract platform dependencies of test module in libraryDeps()") {
+    val build =
+      Build(
+        project = Project("2.12.8", scalaJsVersion = Some("0.6.26")),
+        module = Map(
+          "a" -> Module(
+            targets = List(JVM, JavaScript),
+            test = Some(Module(
+              sources = List(Paths.get("a/test")),
+              scalaDeps = List(Dep("io.monix", "minitest", "2.3.2")))))))
+
+    val libraryDeps = ArtefactResolution.allLibraryDeps(build)
+    assertEquals(libraryDeps, Set(
+      Dep("io.monix", "minitest_2.12", "2.3.2"),
+      Dep("io.monix", "minitest_sjs0.6_2.12", "2.3.2")))
   }
 }

--- a/src/test/scala/seed/config/BuildConfigSpec.scala
+++ b/src/test/scala/seed/config/BuildConfigSpec.scala
@@ -6,6 +6,9 @@ import minitest.SimpleTestSuite
 import java.nio.file.Paths
 
 import org.apache.commons.io.FileUtils
+import seed.model.Build
+import seed.model.Build.Project
+import seed.model.Platform.{JVM, JavaScript}
 
 object BuildConfigSpec extends SimpleTestSuite {
   test("Resolve absolute project path") {
@@ -34,5 +37,37 @@ object BuildConfigSpec extends SimpleTestSuite {
 
     val (projectPath, _) = BuildConfig.load(Paths.get("test/a.toml"))
     assertEquals(projectPath, Paths.get("test"))
+  }
+
+  test("Set target platforms on test modules") {
+    val toml = """
+      |[project]
+      |scalaVersion      = "2.12.4-bin-typelevel-4"
+      |scalaJsVersion    = "0.6.26"
+      |scalaOrganisation = "org.typelevel"
+      |testFrameworks    = ["minitest.runner.Framework"]
+      |
+      |[module.example]
+      |root       = "shared"
+      |sources    = ["shared/src"]
+      |targets    = ["js", "jvm"]
+      |
+      |[module.example.test]
+      |sources   = ["shared/test"]
+      |scalaDeps = [
+      |  ["io.monix", "minitest", "2.3.2"]
+      |]
+      |
+      |[module.example.test.js]
+      |sources = ["js/test"]
+    """.stripMargin
+
+    val buildRaw = BuildConfig.parseToml(Paths.get("."))(toml)
+    val build = BuildConfig.processBuild(buildRaw.right.get, _ =>
+      Build(project = Project(scalaVersion = "2.12.8"), module = Map()))
+
+    assertEquals(
+      build.module("example").test.get.targets,
+      List(JavaScript, JVM))
   }
 }


### PR DESCRIPTION
Pull request #6 uncovered a problem in `ArtefactResolution`: When a test module did not set any target platforms, its dependencies would not be resolved.

Currently, the logic in `BuildConfig` only considers the platform-specific modules defined on a test module. Change the logic to inherit all targets from the parent module.
    
Change the type of `import` on `Build` to `Path` to avoid the duplicated normalisation logic of `fixPath()`.

Also, break `load()` on `Build` apart into separate functions to allow for better testing.