### PR TITLE
 Expose artefact version tag in TOML build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-.idea/
 .bloop/
-build/
 target/
-project/target/
-test/
+/.idea/
+/build/
+/test/

--- a/README.md
+++ b/README.md
@@ -357,6 +357,26 @@ scalaDeps = [
 ]
 ```
 
+On `scalaDeps`, you can specify a fourth parameter for the version tag. The version tag is the actual difference between a Java and Scala dependency.
+
+The Scala naming conventions stipulate that a suffix be added to the artefact name. Thus, `scalaj-http` becomes [`scalaj-http_2.12`](http://central.maven.org/maven2/org/scalaj/scalaj-http_2.12/).
+
+The previous example could be rewritten as:
+
+```toml
+scalaDeps = [
+  ["org.scalaj", "scalaj-http", "2.4.1", "platformBinary"]
+]
+```
+
+The default is `platformBinary` which will suit most libraries. However, some libraries target a specific compiler version or share one artefact with all platforms.
+
+The available options are:
+
+* `binary`: Binary Scala version (e.g. 2.12). This behaves like `full` if the Scala version is a pre-release (e.g. `2.12.8-M3`)
+* `full`: Full Scala version (e.g. `2.11.11`)
+* `platformBinary`: Platform name including the binary Scala version (`native0.3_2.11`)
+
 `scalaDeps` only works with Scala artefacts. For all other artefacts, you can use `javaDeps`:
 
 ```toml

--- a/src/main/scala/seed/cli/Package.scala
+++ b/src/main/scala/seed/cli/Package.scala
@@ -9,7 +9,7 @@ import seed.cli.util.Ansi
 import seed.config.BuildConfig
 import seed.generation.Bloop
 import seed.model
-import seed.model.Build.Dep
+import seed.model.Build.JavaDep
 import seed.model.Config
 import seed.model.Platform.JVM
 import seed.{Cli, Log}
@@ -65,9 +65,9 @@ object Package {
               val scalaVersion = BuildConfig.scalaVersion(build.project,
                 List(jvmModule))
               val scalaLibraryDep =
-                Dep(build.project.scalaOrganisation, "scala-library", scalaVersion)
+                JavaDep(build.project.scalaOrganisation, "scala-library", scalaVersion)
               val scalaReflectDep =
-                Dep(build.project.scalaOrganisation, "scala-reflect", scalaVersion)
+                JavaDep(build.project.scalaOrganisation, "scala-reflect", scalaVersion)
               val platformDeps = Set(scalaLibraryDep, scalaReflectDep)
 
               val libraryDeps = ArtefactResolution.allLibraryDeps(build,

--- a/src/main/scala/seed/cli/Scaffold.scala
+++ b/src/main/scala/seed/cli/Scaffold.scala
@@ -6,7 +6,6 @@ import org.apache.commons.io.FileUtils
 import seed.artefact.{MavenCentral, SemanticVersioning}
 import seed.artefact.MavenCentral.{CompilerVersion, PlatformVersion}
 import seed.cli.util.{Ansi, ColourScheme}
-import seed.model.Artefact.PlatformSuffix
 import seed.model.{Artefact, Organisation, Platform, TestFramework}
 import seed.model.Platform.{JVM, JavaScript, Native}
 import seed.Log
@@ -156,7 +155,7 @@ object Scaffold {
       (if (platforms.contains(Native)) Map((Native, Artefact.ScalaNativePlugin)) else Map())
 
     compilerArtefacts.map { case (platform, artefact) =>
-      if (artefact.platformSuffix == PlatformSuffix.Regular)
+      if (artefact.versionTag.isEmpty)
         platform -> MavenCentral.fetchCompilerVersions(artefact, stable)
       else
         platform -> MavenCentral.fetchPlatformCompilerVersions(artefact, stable)

--- a/src/main/scala/seed/cli/Update.scala
+++ b/src/main/scala/seed/cli/Update.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import seed.artefact.{ArtefactResolution, SemanticVersioning}
 import seed.cli.util.{Ansi, ColourScheme}
 import seed.config.BuildConfig
-import seed.model.Platform
+import seed.model.{Artefact, Platform}
 import seed.model.Platform.{JavaScript, Native}
 
 object Update {
@@ -45,7 +45,7 @@ object Update {
 
     val (compilerVersions, platformVersions, libraryArtefacts) = Scaffold.checkVersions(
       build.project.scalaOrganisation, BuildConfig.buildTargets(build),
-      buildArtefacts.mapValues(_.map(_.artefact)), stable)
+      buildArtefacts.mapValues(_.map(Artefact.fromDep)), stable)
 
     println(Ansi.underlined("Compiler report"))
 
@@ -88,20 +88,20 @@ object Update {
       .sortBy(_._1)(Platform.Ordering)
       .zipWithIndex
       .foreach
-    { case ((platform, artefacts), i) =>
+    { case ((platform, deps), i) =>
       val latestArtefacts = libraryArtefacts.getOrElse(platform, Map())
 
       println(ColourScheme.blue1.toFansi(fansi.Bold.On(platform.caption)))
 
-      artefacts.foreach { artefact =>
+      deps.foreach { dep =>
         // TODO fansi does not support italics
         val description =
           fansi.Str("Dependency ") ++
-          fansi.Underlined.On(artefact.artefact.organisation) + ":" +
-          fansi.Underlined.On(artefact.artefact.name)
-        val newVersion = latestArtefacts.get(artefact.artefact).flatten
+          fansi.Underlined.On(dep.organisation) + ":" +
+          fansi.Underlined.On(dep.artefact)
+        val newVersion = latestArtefacts.get(Artefact.fromDep(dep)).flatten
 
-        compareVersion(description, artefact.version, newVersion)
+        compareVersion(description, dep.version, newVersion)
       }
 
       if (i != buildArtefacts.size - 1) println()

--- a/src/main/scala/seed/config/BuildConfig.scala
+++ b/src/main/scala/seed/config/BuildConfig.scala
@@ -3,7 +3,7 @@ package seed.config
 import java.nio.file.{Files, Path, Paths}
 
 import seed.cli.util.{Ansi, ColourScheme}
-import seed.model.Build.{Dep, Module, Project}
+import seed.model.Build.{JavaDep, Module, Project, ScalaDep}
 import seed.model.Platform.{JVM, JavaScript, Native}
 import seed.model.{Build, Platform}
 import seed.Log
@@ -218,19 +218,19 @@ object BuildConfig {
       buildPath.resolve(targetName(build, name, JVM)) +:
       collectJvmClassPath(buildPath, build, build.module(name)))
 
-  def collectJsDeps(build: Build, module: Module): List[Dep] =
+  def collectJsDeps(build: Build, module: Module): List[ScalaDep] =
     module.scalaDeps ++ module.js.map(_.scalaDeps).getOrElse(List()) ++
     jsModuleDeps(module).flatMap(m => collectJsDeps(build, build.module(m)))
 
-  def collectNativeDeps(build: Build, module: Module): List[Dep] =
+  def collectNativeDeps(build: Build, module: Module): List[ScalaDep] =
     module.scalaDeps ++ module.native.map(_.scalaDeps).getOrElse(List()) ++
     nativeModuleDeps(module).flatMap(m => collectNativeDeps(build, build.module(m)))
 
-  def collectJvmScalaDeps(build: Build, module: Module): List[Dep] =
+  def collectJvmScalaDeps(build: Build, module: Module): List[ScalaDep] =
     module.scalaDeps ++ module.jvm.map(_.scalaDeps).getOrElse(List()) ++
     jvmModuleDeps(module).flatMap(m => collectJvmScalaDeps(build, build.module(m)))
 
-  def collectJvmJavaDeps(build: Build, module: Module): List[Dep] =
+  def collectJvmJavaDeps(build: Build, module: Module): List[JavaDep] =
     module.javaDeps ++ module.jvm.map(_.javaDeps).getOrElse(List()) ++
     jvmModuleDeps(module).flatMap(m => collectJvmJavaDeps(build, build.module(m)))
 

--- a/src/main/scala/seed/config/util/TomlUtils.scala
+++ b/src/main/scala/seed/config/util/TomlUtils.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Path, Paths}
 import org.apache.commons.io.FileUtils
 import seed.Log
 import seed.cli.util.Ansi
+import seed.model.Build.VersionTag
 import seed.model.Platform
 import toml.{Codec, Value}
 
@@ -19,12 +20,24 @@ object TomlUtils {
           case Some(p) => Right(p)
         }
 
-      case (value, _, _) => Left((List.empty, s"Platform expected, $value provided"))
+      case (value, _, _) => Left((List(), s"Platform expected, $value provided"))
+    }
+
+    implicit val versionTagCodec: Codec[VersionTag] = Codec {
+      case (Value.Str(id), _, _) =>
+        id match {
+          case "full" => Right(VersionTag.Full)
+          case "binary" => Right(VersionTag.Binary)
+          case "platformBinary" => Right(VersionTag.PlatformBinary)
+          case _ => Left((List(), "Invalid version tag provided"))
+        }
+
+      case (value, _, _) => Left((List(), s"Version tag expected, $value provided"))
     }
 
     def pathCodec(f: Path => Path): Codec[Path] = Codec {
       case (Value.Str(path), _, _) => Right(f(Paths.get(path)))
-      case (value, _, _) => Left((List.empty, s"Path expected, $value provided"))
+      case (value, _, _) => Left((List(), s"Path expected, $value provided"))
     }
   }
 

--- a/src/main/scala/seed/generation/Bloop.scala
+++ b/src/main/scala/seed/generation/Bloop.scala
@@ -5,7 +5,6 @@ import java.nio.file.{Files, Path, Paths}
 import seed.config.BuildConfig.{collectJsClassPath, collectJsDeps, collectJvmClassPath, collectJvmScalaDeps, collectNativeClassPath, collectNativeDeps}
 import seed.artefact.{Coursier, ArtefactResolution}
 import seed.cli.util.Ansi
-import seed.model.Artefact.PlatformSuffix
 import seed.model.Build.{Module, Project}
 import seed.model.Platform.{JVM, JavaScript, Native}
 import seed.model.{Artefact, Build, Resolution}
@@ -119,7 +118,7 @@ object Bloop {
         val resolvedDeps = Coursier.localArtefacts(
           resolution,
           (scalaDeps ++ js.scalaDeps).map(dep =>
-            ArtefactResolution.dependencyFromDep(
+            ArtefactResolution.javaDepFromScalaDep(
               dep, JavaScript, scalaJsVersion.get, scalaVersion)
           ).toSet)
         val dependencies = if (test) List(name)
@@ -229,7 +228,7 @@ object Bloop {
         val resolvedDeps =
           Coursier.localArtefacts(resolution,
             (scalaDeps ++ native.scalaDeps).map(dep =>
-              ArtefactResolution.dependencyFromDep(dep, Native,
+              ArtefactResolution.javaDepFromScalaDep(dep, Native,
                 scalaNativeVersion.get, scalaVersion)
             ).toSet)
 
@@ -312,12 +311,10 @@ object Bloop {
         val scalaVersion = BuildConfig.scalaVersion(project,
           List(jvm, parentModule.jvm.getOrElse(Module()), parentModule))
 
-        val javaDeps = jvm.javaDeps.map(dep =>
-          ArtefactResolution.dependencyFromDep(dep, JVM,
-            scalaVersion, scalaVersion, PlatformSuffix.Regular))
+        val javaDeps = jvm.javaDeps
         val scalaDeps = (parentModule.scalaDeps ++ jvm.scalaDeps).map(dep =>
-          ArtefactResolution.dependencyFromDep(dep, JVM,
-            scalaVersion, scalaVersion))
+          ArtefactResolution.javaDepFromScalaDep(dep, JVM, scalaVersion,
+            scalaVersion))
 
         val resolvedDeps = Coursier.localArtefacts(resolution,
           (javaDeps ++ scalaDeps).toSet)

--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -8,7 +8,6 @@ import seed.config.BuildConfig.{collectJsDeps, collectJsModuleDeps, collectJvmJa
 import seed.artefact.{Coursier, ArtefactResolution}
 import seed.cli.util.Ansi
 import seed.generation.util.IdeaFile
-import seed.model.Artefact.PlatformSuffix
 import seed.model.{Build, Resolution}
 import seed.model.Build.Module
 import seed.model.Platform.{JVM, JavaScript, Native}
@@ -164,7 +163,7 @@ object Idea {
               _.js.toList.flatMap(_.sources)),
             resolvedDeps = Coursier.localArtefacts(resolution,
               collectJsDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
+                ArtefactResolution.javaDepFromScalaDep(
                   dep, JavaScript,
                   build.project.scalaJsVersion.get,
                   build.project.scalaVersion)
@@ -173,7 +172,7 @@ object Idea {
             resolvedTestDeps = module.test.toList.flatMap(test =>
               Coursier.localArtefacts(resolution,
                 collectJsDeps(build, test).map(dep =>
-                  ArtefactResolution.dependencyFromDep(
+                  ArtefactResolution.javaDepFromScalaDep(
                     dep, JavaScript,
                     build.project.scalaJsVersion.get,
                     build.project.scalaVersion)
@@ -210,16 +209,9 @@ object Idea {
             tests = module.test.toList.flatMap(
               _.jvm.toList.flatMap(_.sources)),
             resolvedDeps = Coursier.localArtefacts(resolution,
-              collectJvmJavaDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
-                  dep, JVM,
-                  build.project.scalaVersion,
-                  build.project.scalaVersion,
-                  PlatformSuffix.Regular
-                )
-              ).toSet ++
+              collectJvmJavaDeps(build, module).toSet ++
               collectJvmScalaDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
+                ArtefactResolution.javaDepFromScalaDep(
                   dep, JVM,
                   build.project.scalaVersion,
                   build.project.scalaVersion)
@@ -228,7 +220,7 @@ object Idea {
             resolvedTestDeps = module.test.toSet.flatMap(test =>
               Coursier.localArtefacts(resolution,
                 collectJvmScalaDeps(build, test).map(dep =>
-                  ArtefactResolution.dependencyFromDep(
+                  ArtefactResolution.javaDepFromScalaDep(
                     dep, JVM,
                     build.project.scalaVersion,
                     build.project.scalaVersion)
@@ -268,7 +260,7 @@ object Idea {
             resolvedDeps = Coursier.localArtefacts(
               resolution,
               collectNativeDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
+                ArtefactResolution.javaDepFromScalaDep(
                   dep, Native,
                   build.project.scalaNativeVersion.get,
                   build.project.scalaVersion)
@@ -277,7 +269,7 @@ object Idea {
             resolvedTestDeps = module.test.toList.flatMap(test =>
               Coursier.localArtefacts(resolution,
                 collectNativeDeps(build, test).map(dep =>
-                  ArtefactResolution.dependencyFromDep(
+                  ArtefactResolution.javaDepFromScalaDep(
                     dep, Native,
                     build.project.scalaNativeVersion.get,
                     build.project.scalaVersion)
@@ -312,16 +304,9 @@ object Idea {
             sources = module.sources,
             tests = module.test.toList.flatMap(_.sources),
             resolvedDeps = Coursier.localArtefacts(resolution,
-              collectJvmJavaDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
-                  dep, JVM,
-                  build.project.scalaVersion,
-                  build.project.scalaVersion,
-                  PlatformSuffix.Regular
-                )
-              ).toSet ++
+              collectJvmJavaDeps(build, module).toSet ++
               collectJvmScalaDeps(build, module).map(dep =>
-                ArtefactResolution.dependencyFromDep(
+                ArtefactResolution.javaDepFromScalaDep(
                   dep, JVM,
                   build.project.scalaVersion,
                   build.project.scalaVersion)
@@ -330,7 +315,7 @@ object Idea {
             resolvedTestDeps = module.test.toSet.flatMap(test =>
               Coursier.localArtefacts(resolution,
                 collectJvmScalaDeps(build, test).map(dep =>
-                  ArtefactResolution.dependencyFromDep(
+                  ArtefactResolution.javaDepFromScalaDep(
                     dep, JVM,
                     build.project.scalaVersion,
                     build.project.scalaVersion)

--- a/src/main/scala/seed/model/Artefact.scala
+++ b/src/main/scala/seed/model/Artefact.scala
@@ -1,42 +1,41 @@
 package seed.model
 
+import seed.model.Build.{Dep, JavaDep, ScalaDep, VersionTag}
+
 case class Artefact(organisation: String,
                     name: String,
-                    platformSuffix: Artefact.PlatformSuffix)
+                    versionTag: Option[VersionTag])
 
 object Artefact {
-  case class Versioned(artefact: Artefact, version: String)
+  import VersionTag._
 
-  sealed trait PlatformSuffix
-  object PlatformSuffix {
-    case object PlatformAndCompiler extends PlatformSuffix
-    case object Compiler extends PlatformSuffix
-    case object CompilerLibrary extends PlatformSuffix
-    case object Regular extends PlatformSuffix
-  }
-
-  import PlatformSuffix._
+  def fromDep(dep: Dep): Artefact =
+    dep match {
+      case JavaDep(org, name, _) => Artefact(org, name, None)
+      case ScalaDep(org, name, _, versionTag) =>
+        Artefact(org, name, Some(versionTag))
+    }
 
   def scalaCompiler(organisation: String) =
-    Artefact(organisation, "scala-compiler", Regular)
+    Artefact(organisation, "scala-compiler", None)
   def scalaLibrary(organisation: String) =
-    Artefact(organisation, "scala-library", Regular)
+    Artefact(organisation, "scala-library", None)
   def scalaReflect(organisation: String) =
-    Artefact(organisation, "scala-reflect", Regular)
+    Artefact(organisation, "scala-reflect", None)
 
-  val CompilerBridge = Artefact("ch.epfl.scala", "compiler-bridge", Compiler)
+  val CompilerBridge = Artefact("ch.epfl.scala", "compiler-bridge", Some(Full))
 
-  val ScalaJsCompiler = Artefact("org.scala-js", "scalajs-compiler", Compiler)
-  val ScalaJsLibrary  = Artefact("org.scala-js", "scalajs-library", CompilerLibrary)
+  val ScalaJsCompiler = Artefact("org.scala-js", "scalajs-compiler", Some(Full))
+  val ScalaJsLibrary  = Artefact("org.scala-js", "scalajs-library", Some(Binary))
 
-  val ScalaNativePlugin    = Artefact("org.scala-native", "nscplugin", Compiler)
-  val ScalaNativeJavalib   = Artefact("org.scala-native", "javalib", PlatformAndCompiler)
-  val ScalaNativeScalalib  = Artefact("org.scala-native", "scalalib", PlatformAndCompiler)
-  val ScalaNativeNativelib = Artefact("org.scala-native", "nativelib", PlatformAndCompiler)
-  val ScalaNativeAuxlib    = Artefact("org.scala-native", "auxlib", PlatformAndCompiler)
+  val ScalaNativePlugin    = Artefact("org.scala-native", "nscplugin", Some(Full))
+  val ScalaNativeJavalib   = Artefact("org.scala-native", "javalib", Some(PlatformBinary))
+  val ScalaNativeScalalib  = Artefact("org.scala-native", "scalalib", Some(PlatformBinary))
+  val ScalaNativeNativelib = Artefact("org.scala-native", "nativelib", Some(PlatformBinary))
+  val ScalaNativeAuxlib    = Artefact("org.scala-native", "auxlib", Some(PlatformBinary))
 
-  val Minitest   = Artefact("io.monix", "minitest", PlatformAndCompiler)
-  val ScalaTest  = Artefact("org.scalatest", "scalatest", PlatformAndCompiler)
-  val ScalaCheck = Artefact("org.scalacheck", "scalacheck", PlatformAndCompiler)
-  val Utest      = Artefact("com.lihaoyi", "utest", PlatformAndCompiler)
+  val Minitest   = Artefact("io.monix", "minitest", Some(PlatformBinary))
+  val ScalaTest  = Artefact("org.scalatest", "scalatest", Some(PlatformBinary))
+  val ScalaCheck = Artefact("org.scalacheck", "scalacheck", Some(PlatformBinary))
+  val Utest      = Artefact("com.lihaoyi", "utest", Some(PlatformBinary))
 }

--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -21,8 +21,11 @@ object Build {
 
   sealed trait VersionTag
   object VersionTag {
-    /** Binary Scala version (e.g. 2.12). This behaves as Full if the Scala
-      * version is a pre-release (e.g. 2.12.8-M3).
+    /**
+      * Binary Scala version (e.g. 2.12)
+      *
+      * This behaves like [[Full]] if the Scala version is a pre-release (e.g.
+      * 2.12.8-M3).
       */
     case object Binary extends VersionTag
 

--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -10,19 +10,48 @@ case class Build(`import`: List[Path] = List(),
                  module: Map[String, Build.Module])
 
 object Build {
-  case class Dep(organisation: String, artefact: String, version: String)
+  sealed trait Dep {
+    def organisation: String
+    def artefact: String
+    def version: String
+  }
+
+  case class JavaDep(organisation: String, artefact: String, version: String)
+    extends Dep
+
+  sealed trait VersionTag
+  object VersionTag {
+    /** Binary Scala version (e.g. 2.12). This behaves as Full if the Scala
+      * version is a pre-release (e.g. 2.12.8-M3).
+      */
+    case object Binary extends VersionTag
+
+    /** Full Scala version (e.g. 2.11.11) */
+    case object Full extends VersionTag
+
+    /** Platform name including binary Scala version (e.g. native0.3_2.11) */
+    case object PlatformBinary extends VersionTag
+  }
+
+  case class ScalaDep(organisation: String,
+                      artefact: String,
+                      version: String,
+                      versionTag: VersionTag = VersionTag.PlatformBinary
+                     ) extends Dep
+
   case class Project(scalaVersion: String,
                      scalaJsVersion: Option[String] = None,
                      scalaNativeVersion: Option[String] = None,
                      scalaOptions: List[String] = List(),
                      scalaOrganisation: String = Organisation.Lightbend.packageName,
                      testFrameworks: List[String] = List())
+
   case class Module(scalaVersion: Option[String] = None,
                     root: Option[Path] = None,
                     sources: List[Path] = List(),
                     resources: List[Path] = List(),
-                    scalaDeps: List[Dep] = List(),
-                    javaDeps: List[Dep] = List(),
+                    scalaDeps: List[ScalaDep] = List(),
+                    javaDeps: List[JavaDep] = List(),
                     moduleDeps: List[String] = List(),
                     mainClass: Option[String] = None,
                     targets: List[Platform] = List(),

--- a/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
+++ b/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
@@ -3,19 +3,26 @@ package seed.artefact
 import java.nio.file.Paths
 
 import minitest.SimpleTestSuite
-import seed.model.Build.Dep
+import seed.model.Build.{JavaDep, Module, Project, ScalaDep, VersionTag}
 import seed.model.Platform.JavaScript
-import seed.model.Build.{Module, Project}
 import seed.model.Platform.JVM
 import seed.model.Build
 
 object ArtefactResolutionSpec extends SimpleTestSuite {
-  test("dependencyFromDep()") {
-    val scalaDep = Dep("org.scala-js", "scalajs-dom", "0.9.6")
-    val javaDep = ArtefactResolution.dependencyFromDep(
+  test("dependencyFromScalaDep() with Scala.js dependency") {
+    val scalaDep = ScalaDep("org.scala-js", "scalajs-dom", "0.9.6")
+    val javaDep = ArtefactResolution.javaDepFromScalaDep(
       scalaDep, JavaScript, "0.6", "2.12")
     assertEquals(javaDep,
-      Dep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6"))
+      JavaDep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6"))
+  }
+
+  test("dependencyFromScalaDep() with Scala JVM dependency (full Scala version)") {
+    val scalaDep = ScalaDep(
+      "org.scalameta", "interactive", "4.1.0", VersionTag.Full)
+    val javaDep = ArtefactResolution.javaDepFromScalaDep(
+      scalaDep, JVM, "2.12.8", "2.12.8")
+    assertEquals(javaDep, JavaDep("org.scalameta", "interactive_2.12.8", "4.1.0"))
   }
 
   test("Extract platform dependencies of test module in libraryDeps()") {
@@ -27,11 +34,22 @@ object ArtefactResolutionSpec extends SimpleTestSuite {
             targets = List(JVM, JavaScript),
             test = Some(Module(
               sources = List(Paths.get("a/test")),
-              scalaDeps = List(Dep("io.monix", "minitest", "2.3.2")))))))
+              scalaDeps = List(ScalaDep("io.monix", "minitest", "2.3.2")))))))
 
     val libraryDeps = ArtefactResolution.allLibraryDeps(build)
     assertEquals(libraryDeps, Set(
-      Dep("io.monix", "minitest_2.12", "2.3.2"),
-      Dep("io.monix", "minitest_sjs0.6_2.12", "2.3.2")))
+      JavaDep("io.monix", "minitest_2.12", "2.3.2"),
+      JavaDep("io.monix", "minitest_sjs0.6_2.12", "2.3.2")))
+  }
+
+  test("jvmDeps()") {
+    val build = Build(project = Project("2.12.8"), module = Map())
+    val module = Module(
+      scalaDeps = List(ScalaDep("io.monix", "minitest", "2.3.2")),
+      javaDeps = List(JavaDep("net.java.dev.jna", "jna", "4.5.1")))
+    val deps = ArtefactResolution.jvmDeps(build, List(module))
+    assertEquals(deps, Set(
+      JavaDep("io.monix", "minitest_2.12", "2.3.2"),
+      JavaDep("net.java.dev.jna", "jna", "4.5.1")))
   }
 }

--- a/src/test/scala/seed/artefact/CoursierSpec.scala
+++ b/src/test/scala/seed/artefact/CoursierSpec.scala
@@ -2,11 +2,11 @@ package seed.artefact
 
 import minitest.SimpleTestSuite
 import seed.model.Build
-import seed.model.Build.Dep
+import seed.model.Build.JavaDep
 
 object CoursierSpec extends SimpleTestSuite {
   test("Resolve dependency") {
-    val dep = Dep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6")
+    val dep = JavaDep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6")
     val resolution = Coursier.resolveAndDownload(Set(dep),
       Build.Resolvers(), Coursier.DefaultIvyPath,
       Coursier.DefaultCachePath, optionalArtefacts = true)


### PR DESCRIPTION
Currently, the version tag for dependencies in the TOML file always
encodes the platform name and binary Scala version. Internally,
Seed already has to handle different version tags. Expose this
functionality in `scalaDep` by introducing a fourth parameter. The
detailed changes for this are:

- `Build`: Introduce `VersionTag` which was previously called
  `PlatformSuffix` and located in `Artefact`
- `Build`: Make `Dep` a sealed trait with two children, `JavaDep` and
  `ScalaDep`, the only difference between those two being that
  `ScalaDep` has a `VersionTag` parameter. The version tag defaults
  to `PlatformBinary` in order to retain compatibility.
- `TomlUtils`: Introduce codec for parsing `VersionTag` values
- `Artefact`: Remove `Versioned` in favour of `Dep`
- `Artefact`: Provide function for `Dep` → `Artefact` conversions
- `ArtefactResolution`: Refactor functions for collecting
  dependencies