### PR TITLE
Implement link command and WebSocket interface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,20 +34,25 @@ Compile / sourceGenerators += Def.task {
 }.taskValue
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi"     %% "fansi"          % "0.2.5",
-  "io.get-coursier" %% "coursier"       % bloopCoursierVersion,
-  "io.get-coursier" %% "coursier-cache" % bloopCoursierVersion,
-  "tech.sparse"     %% "toml-scala"     % "0.2.0",
-  "tech.sparse"     %% "pine"           % "0.1.3",
-  "ch.epfl.scala"   %% "bloop-config"   % bloopVersion,
-  "com.joefkelley"  %% "argyle"         % "1.0.0",
-  "org.scalaj"      %% "scalaj-http"    % "2.4.1",
-  "commons-io"      %  "commons-io"     % "2.6",
-  "com.zaxxer"      %  "nuprocess"      % "1.2.4" % "test",
-  "io.monix"        %% "minitest"       % "2.3.2" % "test",
+  "com.lihaoyi"        %% "fansi"          % "0.2.5",
+  "io.get-coursier"    %% "coursier"       % bloopCoursierVersion,
+  "io.get-coursier"    %% "coursier-cache" % bloopCoursierVersion,
+  "tech.sparse"        %% "toml-scala"     % "0.2.0",
+  "tech.sparse"        %% "pine"           % "0.1.3",
+  "ch.epfl.scala"      %% "bloop-config"   % bloopVersion,
+  "com.joefkelley"     %% "argyle"         % "1.0.0",
+  "org.scalaj"         %% "scalaj-http"    % "2.4.1",
+  "io.circe"           %% "circe-core"     % "0.11.1",
+  "commons-io"         %  "commons-io"     % "2.6",
+  "com.zaxxer"         %  "nuprocess"      % "1.2.4",
+  "org.java-websocket" %  "Java-WebSocket" % "1.3.9",
+  "io.monix"           %% "minitest"       % "2.3.2" % "test",
 
   scalaOrganization.value % "scala-reflect" % scalaVersion.value
 )
+
+run / fork := true
+Global / cancelable := true
 
 testFrameworks += new TestFramework("minitest.runner.Framework")
 

--- a/src/main/scala/seed/Log.scala
+++ b/src/main/scala/seed/Log.scala
@@ -3,16 +3,18 @@ package seed
 import seed.cli.util.Ansi._
 import seed.cli.util.ColourScheme._
 
-object Log {
+class Log(f: String => Unit) {
   def error(message: String): Unit =
-    println(foreground(red2)(bold("[error]") + " " + message))
+    f(foreground(red2)(bold("[error]") + " " + message))
 
   def warn(message: String): Unit =
-    println(foreground(yellow2)(bold("[warn]") + " " + message))
+    f(foreground(yellow2)(bold("[warn]") + " " + message))
 
   def debug(message: String): Unit =
-    println(foreground(green2)(bold("[debug]") + " " + message))
+    f(foreground(green2)(bold("[debug]") + " " + message))
 
   def info(message: String): Unit =
-    println(foreground(blue2)(bold("[info]") + " " + message))
+    f(foreground(blue2)(bold("[info]") + " " + message))
 }
+
+object Log extends Log(println)

--- a/src/main/scala/seed/build/Link.scala
+++ b/src/main/scala/seed/build/Link.scala
@@ -24,7 +24,7 @@ object Link {
     if (moduleNames.isEmpty) None
     else {
       val args = "link" +: ((if (!watch) List() else List("--watch")) ++ moduleNames)
-      Some(ProcessHelper.runBloop(projectPath, silent = true, onStdOut)(args: _*))
+      Some(ProcessHelper.runBloop(projectPath, onStdOut)(args: _*))
     }
   }
 }

--- a/src/main/scala/seed/build/Link.scala
+++ b/src/main/scala/seed/build/Link.scala
@@ -1,0 +1,30 @@
+package seed.build
+
+import java.nio.file.Path
+
+import seed.Log
+import seed.cli.util.BloopCli
+import seed.model.{Build, Platform}
+import seed.process.ProcessHelper
+
+object Link {
+  type Module = (String, Option[Platform])
+
+  def link(build: Build,
+           projectPath: Path,
+           modules: List[Module],
+           watch: Boolean,
+           log: Log,
+           onStdOut: String => Unit
+          ): Option[ProcessHelper.Process] = {
+    val moduleNames = modules.flatMap { case (name, platform) =>
+      BloopCli.bloopModuleNames(build, name, platform, log)
+    }
+
+    if (moduleNames.isEmpty) None
+    else {
+      val args = "link" +: ((if (!watch) List() else List("--watch")) ++ moduleNames)
+      Some(ProcessHelper.runBloop(projectPath, silent = true, onStdOut)(args: _*))
+    }
+  }
+}

--- a/src/main/scala/seed/cli/Build.scala
+++ b/src/main/scala/seed/cli/Build.scala
@@ -2,7 +2,7 @@ package seed.cli
 
 import java.nio.file.Path
 
-import seed.model
+import seed.{Log, model}
 import seed.Cli.Command
 import seed.generation.{Bloop, Idea}
 import seed.artefact.ArtefactResolution
@@ -14,9 +14,9 @@ object Build {
          build: model.Build,
          command: Command.Build
         ): Unit = {
-    build.module.toList.foreach { case (name, module) =>
-      BuildConfig.checkModule(build, name, module)
-    }
+    if (!build.module.toList.forall { case (name, module) =>
+      BuildConfig.checkModule(build, name, module, Log)
+    }) sys.exit(1)
 
     val compilerDeps = ArtefactResolution.allCompilerDeps(build)
     val platformDeps = ArtefactResolution.allPlatformDeps(build)

--- a/src/main/scala/seed/cli/BuildEvents.scala
+++ b/src/main/scala/seed/cli/BuildEvents.scala
@@ -1,0 +1,24 @@
+package seed.cli
+
+import java.net.URI
+import java.nio.file.Path
+
+import seed.Log
+import seed.cli.util.{Ansi, BloopCli, WsClient}
+import seed.config.BuildConfig
+import seed.model.Platform
+import seed.process.ProcessHelper
+import seed.Cli.Command
+
+object BuildEvents {
+  def ui(command: Command.BuildEvents): Unit = {
+    val connection = command.webSocket
+    val uri = s"ws://${connection.host}:${connection.port}"
+    Log.debug(s"Sending command to $uri...")
+    val client = new WsClient(new URI(uri), () => {
+      import io.circe.syntax._
+      (WsCommand.BuildEvents: WsCommand).asJson.noSpaces
+    })
+    client.connect()
+  }
+}

--- a/src/main/scala/seed/cli/Link.scala
+++ b/src/main/scala/seed/cli/Link.scala
@@ -1,0 +1,60 @@
+package seed.cli
+
+import java.net.URI
+import java.nio.file.Path
+
+import seed.Log
+import seed.cli.util.{Ansi, WsClient}
+import seed.config.BuildConfig
+import seed.model.Platform
+import seed.Cli.Command
+
+object Link {
+  def parseCliModuleName(module: String): (String, Option[Platform]) =
+    if (!module.contains(":")) (module, None)
+    else {
+      val parts = module.split(":")
+      if (parts.length != 2) {
+        Log.error(s"Expected syntax: ${Ansi.italic("<name>:<platform>")}")
+        sys.exit(1)
+      }
+
+      val name = parts(0)
+      val platform = Platform.All.find(_._1.id == parts(1)).map(_._1).getOrElse {
+        Log.error(s"Invalid platform ${Ansi.italic(parts(1))} provided")
+        sys.exit(1)
+      }
+
+      (name, Some(platform))
+    }
+
+  def ui(buildPath: Path, command: Command.Link): Unit = {
+    command.webSocket match {
+      case Some(connection) =>
+        if (command.watch)
+          Log.error("--watch cannot be combined with --connect")
+
+        val uri = s"ws://${connection.host}:${connection.port}"
+        Log.debug(s"Sending command to $uri...")
+        val client = new WsClient(new URI(uri), () => {
+          import io.circe.syntax._
+          val build =
+            if (buildPath.isAbsolute) buildPath else buildPath.toAbsolutePath
+          (WsCommand.Link(build, command.modules.map { module =>
+            val (name, platform) = parseCliModuleName(module)
+            WsCommand.Module(name, platform)
+          }): WsCommand).asJson.noSpaces
+        })
+        client.connect()
+
+      case None =>
+        BuildConfig.load(buildPath, Log) match {
+          case None => sys.exit(1)
+          case Some((projectPath, build)) =>
+            val modules = command.modules.map(parseCliModuleName)
+            seed.build.Link.link(build, projectPath, modules, command.watch,
+              Log, println)
+        }
+    }
+  }
+}

--- a/src/main/scala/seed/cli/Server.scala
+++ b/src/main/scala/seed/cli/Server.scala
@@ -1,0 +1,117 @@
+package seed.cli
+
+import java.net.InetSocketAddress
+import java.nio.file.{Path, Paths}
+
+import io.circe.syntax._
+import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import org.java_websocket.WebSocket
+import seed.Log
+import seed.cli.util.{BloopCli, WsServer}
+import seed.config.BuildConfig
+import seed.model
+import seed.model.Platform
+import seed.Cli.Command
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import scala.concurrent.ExecutionContext.Implicits._
+
+sealed trait WsCommand
+object WsCommand {
+  case class Module(name: String, platform: Option[Platform])
+  case class Link(build: Path, modules: List[Module]) extends WsCommand
+  case object BuildEvents extends WsCommand
+
+  implicit val decodeModule: Decoder[Module] = json =>
+    for {
+      name     <- json.downField("name").as[String]
+      platform <- json.downField("platform").as[Option[String]]
+    } yield Module(
+      name,
+      platform.flatMap(p => Platform.All.keys.find(_.id == p)))
+
+  implicit val encodeModule: Encoder[Module] = module =>
+    Json.fromFields(List(
+      "name" -> Json.fromString(module.name),
+      "platform" ->
+        implicitly[Encoder[Option[String]]].apply(module.platform.map(_.id))))
+
+
+  implicit val decodeLink: Decoder[Link] = json =>
+    for {
+      build    <- json.downField("build").as[String].map(Paths.get(_))
+      modules  <- json.downField("modules").as[List[Module]]
+    } yield Link(build, modules)
+
+  val encodeLink: Link => List[(String, Json)] = link =>
+    List(
+      "build" -> Json.fromString(link.build.toString),
+      "modules" -> implicitly[Encoder[List[Module]]].apply(link.modules))
+
+  implicit val decodeCommand: Decoder[WsCommand] = json =>
+    for {
+      commandName <- json.downField("command").as[String]
+      command <-
+        if (commandName == "link") json.as[Link]
+        else if (commandName == "buildEvents") Right(BuildEvents)
+        else Left(DecodingFailure(s"Invalid command: $commandName", json.history))
+    } yield command
+
+  implicit val encodeCommand: Encoder[WsCommand] = {
+    case link: WsCommand.Link =>
+      Json.fromFields(
+        List("command" -> Json.fromString("link")) ++ encodeLink(link))
+    case BuildEvents =>
+      Json.fromFields(List("command" -> Json.fromString("buildEvents")))
+  }
+}
+
+object Server {
+  private val buildEventClients = mutable.HashSet[WebSocket]()
+
+  def ui(command: Command.Server): Unit = {
+    val wsConfig = command.webSocket
+    val webSocket = new WsServer(
+      new InetSocketAddress(wsConfig.host, wsConfig.port), onDisconnect,
+      evalCommand)
+    webSocket.start()
+    Log.info(s"WebSocket server started on ${wsConfig.host}:${wsConfig.port}")
+  }
+
+  def onStdOut(wsServer: WsServer, wsClient: WebSocket, build: model.Build)
+              (message: String): Unit = {
+    wsClient.send(message)
+
+    if (buildEventClients.nonEmpty) {
+      val event = BloopCli.parseStdOut(build)(message)
+      event.foreach { ev =>
+        Log.debug(s"Broadcasting event to ${buildEventClients.size} clients...")
+        wsServer.broadcast(ev.asJson.noSpaces, buildEventClients.toList.asJava)
+      }
+    }
+  }
+
+  def onDisconnect(wsClient: WebSocket): Unit = buildEventClients -= wsClient
+
+  def evalCommand(wsServer: WsServer,
+                  wsClient: WebSocket,
+                  command: WsCommand
+                 ): Unit = {
+    val log = new Log(wsClient.send)
+    command match {
+      case WsCommand.BuildEvents => buildEventClients += wsClient
+      case WsCommand.Link(buildPath, modules) =>
+        BuildConfig.load(buildPath, log).foreach { case (projectPath, build) =>
+          seed.build.Link.link(build, projectPath,
+            modules.map(m => m.name -> m.platform), watch = false,
+            log, onStdOut(wsServer, wsClient, build)
+          ) match {
+            case None => wsClient.close()
+            case Some(p) => p.termination.foreach(_ => wsClient.close())
+          }
+        }
+    }
+  }
+}

--- a/src/main/scala/seed/cli/Update.scala
+++ b/src/main/scala/seed/cli/Update.scala
@@ -2,6 +2,7 @@ package seed.cli
 
 import java.nio.file.Path
 
+import seed.Log
 import seed.artefact.{ArtefactResolution, SemanticVersioning}
 import seed.cli.util.{Ansi, ColourScheme}
 import seed.config.BuildConfig
@@ -39,7 +40,8 @@ object Update {
     }
 
   def ui(path: Path, stable: Boolean): Unit = {
-    val (projectPath, build) = BuildConfig.load(path)
+    val (projectPath, build) = BuildConfig.load(path, Log)
+      .getOrElse(sys.exit(1))
 
     val buildArtefacts = ArtefactResolution.allLibraryArtefacts(build)
 

--- a/src/main/scala/seed/cli/util/ArgyleHelpers.scala
+++ b/src/main/scala/seed/cli/util/ArgyleHelpers.scala
@@ -1,0 +1,33 @@
+package seed.cli.util
+
+import scala.util.{Success, Try}
+import com.joefkelley.argyle._
+
+object ArgyleHelpers {
+  case class OptionalFreeFlagParser
+  (flag: String, collected: Option[String]) extends Arg[Option[String]] {
+    override def visit(xs: NonEmptyList[String], mode: ArgMode): Seq[VisitResult[Option[String]]] = mode match {
+      case EqualsSeparated =>
+        xs match {
+          case NonEmptyList(first, rest) =>
+            if (flag == first) Seq(VisitConsume(copy(collected = Some("")), rest))
+            else if (first.startsWith(flag + '='))
+              Seq(VisitConsume(copy(collected = Some(first.drop(flag.length + 1))), rest))
+            else Seq(VisitNoop)
+        }
+
+      case _ => ???
+    }
+
+    override def complete: Try[Option[String]] = Success(collected)
+  }
+
+  /**
+    * Parser for flags that take an optional value
+    *
+    * Examples:
+    *  --name maps to Some("")
+    *  --name=value maps to Some("value")
+    */
+  def optionalFreeFlag(flag: String): Arg[Option[String]] = OptionalFreeFlagParser(flag, None)
+}

--- a/src/main/scala/seed/cli/util/BloopCli.scala
+++ b/src/main/scala/seed/cli/util/BloopCli.scala
@@ -1,0 +1,68 @@
+package seed.cli.util
+
+import seed.config.BuildConfig
+import seed.{Log, model}
+import seed.model.BuildEvent
+import seed.model.Platform.{JVM, JavaScript, Native}
+import seed.model.Platform
+
+object BloopCli {
+  /**
+    * Check needed because Bloop clears screen
+    *
+    * See https://github.com/scalacenter/bloop/pull/639/files
+    */
+  def skipOutput(output: String): Boolean = output.contains("\u001b[H\u001b[2J")
+
+  def bloopModuleNames(build: model.Build,
+                       module: String,
+                       platform: Option[Platform],
+                       log: Log
+                      ): List[String] =
+    (module, platform) match {
+      case (name, None) =>
+        BuildConfig.linkTargets(build, name)
+        if (build.module.isDefinedAt(name)) BuildConfig.linkTargets(build, name)
+        else {
+          log.error(s"Invalid module provided: $name")
+          List()
+        }
+
+      case (name, Some(p)) =>
+        if (build.module.isDefinedAt(name))
+          List(BuildConfig.targetName(build, name, p))
+        else {
+          log.error(s"Invalid module provided: $name")
+          List()
+        }
+    }
+
+  def parseBloopModule(build: model.Build, bloopName: String): (String, Platform) =
+    if (bloopName.endsWith("-js")) (bloopName.dropRight("-js".length), JavaScript)
+    else if (bloopName.endsWith("-jvm")) (bloopName.dropRight("-jvm".length), JVM)
+    else if (bloopName.endsWith("-native")) (bloopName.dropRight("-native".length), Native)
+    else {
+      require(build.module(bloopName).targets.length == 1, "Only one target expected")
+      (bloopName, build.module(bloopName).targets.head)
+    }
+
+  def parseStdOut(build: model.Build)(message: String): Option[BuildEvent] = {
+    val parts = message.split(" ")
+    if (parts(0) == "Compiling") {
+      val (module, platform) = parseBloopModule(build, parts(1))
+      Some(BuildEvent.Compiling(module, platform))
+    } else if (parts(0) == "Compiled") {
+      val (module, platform) = parseBloopModule(build, parts(1))
+      Some(BuildEvent.Compiled(module, platform))
+    } else if (parts(0) == "Generated") {
+      val offset = message.indexOf('\'')
+      val path = message.substring(offset + 1).init
+      Some(BuildEvent.Linked(path))
+    } else if (message.endsWith("failed to compile.")) {
+      val offset = message.indexOf('\'')
+      val offsetEnd = message.indexOf('\'', offset + 1)
+      val module = message.substring(offset + 1, offsetEnd)
+      Some(BuildEvent.Failed(module))
+    } else None
+  }
+}

--- a/src/main/scala/seed/cli/util/WsClient.scala
+++ b/src/main/scala/seed/cli/util/WsClient.scala
@@ -1,0 +1,23 @@
+package seed.cli.util
+
+import java.net.URI
+import java.nio.ByteBuffer
+
+import org.java_websocket.client.WebSocketClient
+import org.java_websocket.handshake.ServerHandshake
+import seed.Log
+
+class WsClient(serverUri: URI, payload: () => String)
+  extends WebSocketClient(serverUri)
+{
+  override def onOpen(handshake: ServerHandshake): Unit = {
+    Log.debug("Connection established")
+    send(payload())
+  }
+  override def onClose(code: Int, reason: String, remote: Boolean): Unit =
+    Log.debug("Connection closed")
+  override def onMessage(message: String): Unit = println(message)
+  override def onMessage(message: ByteBuffer): Unit = {}
+  override def onError(ex: Exception): Unit =
+    Log.error(s"An error occurred: $ex")
+}

--- a/src/main/scala/seed/cli/util/WsServer.scala
+++ b/src/main/scala/seed/cli/util/WsServer.scala
@@ -1,0 +1,42 @@
+package seed.cli.util
+
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+
+import org.java_websocket.WebSocket
+import org.java_websocket.handshake.ClientHandshake
+import org.java_websocket.server.WebSocketServer
+
+import io.circe.parser.decode
+
+import seed.Log
+import seed.cli.WsCommand
+
+class WsServer(address: InetSocketAddress,
+               onDisconnect: WebSocket => Unit,
+               evalCommand: (WsServer, WebSocket, WsCommand) => Unit
+              ) extends WebSocketServer(address) {
+  setReuseAddr(true)
+
+  def clientIp(conn: WebSocket): String = conn.getRemoteSocketAddress.getAddress.getHostAddress
+
+  override def onOpen(conn: WebSocket, handshake: ClientHandshake): Unit =
+    Log.debug("Client " + clientIp(conn) + " connected")
+  override def onClose(conn: WebSocket, code: Int, reason: String, remote: Boolean): Unit = {
+    Log.debug("Client " + clientIp(conn) + " disconnected")
+    onDisconnect(conn)
+  }
+  override def onError(conn: WebSocket, ex: Exception): Unit = ex.printStackTrace()
+  override def onStart(): Unit = setConnectionLostTimeout(100)
+  override def onMessage(conn: WebSocket, message: String): Unit = {
+    decode[WsCommand](message) match {
+      case Left(e) =>
+        Log.error("Could not process message from " + clientIp(conn) + ": " + e)
+        conn.send(e.toString)
+      case Right(c) =>
+        Log.debug("Message from " + clientIp(conn) + ": " + c)
+        evalCommand(this, conn, c)
+    }
+  }
+  override def onMessage(conn: WebSocket, message: ByteBuffer): Unit = {}
+}

--- a/src/main/scala/seed/config/SeedConfig.scala
+++ b/src/main/scala/seed/config/SeedConfig.scala
@@ -20,7 +20,8 @@ object SeedConfig {
     implicit val pCodec = pathCodec(identity)
 
     def parse(path: Path) =
-      TomlUtils.parseFile(path, Toml.parseAs[Config](_), "Seed configuration")
+      TomlUtils.parseFile(path, Toml.parseAs[Config](_), "Seed configuration", Log)
+        .getOrElse(sys.exit(1))
 
     userConfigPath match {
       case None =>

--- a/src/main/scala/seed/model/BuildEvent.scala
+++ b/src/main/scala/seed/model/BuildEvent.scala
@@ -1,0 +1,28 @@
+package seed.model
+
+import io.circe.{Encoder, Json}
+
+sealed abstract class BuildEvent(val id: String)
+object BuildEvent {
+  case class Compiled(module: String, platform: Platform) extends BuildEvent("compiled")
+  case class Compiling(module: String, platform: Platform) extends BuildEvent("compiling")
+  case class Failed(module: String) extends BuildEvent("failed")
+  case class Linked(path: String) extends BuildEvent("linked")
+
+  implicit val encodeBuildEvent: Encoder[BuildEvent] = be => Json.fromFields(
+    List("event" -> Json.fromString(be.id)) ++
+    (be match {
+      case Compiled(module, platform) =>
+        List(
+          "module" -> Json.fromString(module),
+          "platform" -> Json.fromString(platform.id))
+      case Compiling(module, platform) =>
+        List(
+          "module" -> Json.fromString(module),
+          "platform" -> Json.fromString(platform.id))
+      case Failed(module) => List("module" -> Json.fromString(module))
+      case Linked(path) =>
+        List("path" -> Json.fromString(path))
+    })
+  )
+}

--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -2,18 +2,25 @@ package seed.build
 
 import java.nio.file.Paths
 
-import minitest.SimpleTestSuite
+import scala.concurrent.Future
+import scala.collection.mutable.ListBuffer
+
+import minitest.TestSuite
+
 import seed.Log
 import seed.cli.util.BloopCli
 import seed.generation.util.{ProjectGeneration, TestProcessHelper}
 import seed.model.{BuildEvent, Platform}
+import seed.generation.util.TestProcessHelper.ec
 
-import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext.Implicits._
-import scala.concurrent.{Future, Promise}
+object LinkSpec extends TestSuite[Unit] {
+  override def setupSuite(): Unit = TestProcessHelper.semaphore.acquire()
+  override def tearDownSuite(): Unit = TestProcessHelper.semaphore.release()
 
-object LinkSpec extends SimpleTestSuite {
-  testAsync("Link module and interpret Bloop events") {
+  override def setup(): Unit = ()
+  override def tearDown(env: Unit): Unit = ()
+
+  testAsync("Link module and interpret Bloop events") { _ =>
     val projectPath = Paths.get("test/module-link")
     val build = ProjectGeneration.generateBloopProject(projectPath)
 

--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -1,0 +1,42 @@
+package seed.build
+
+import java.nio.file.Paths
+
+import minitest.SimpleTestSuite
+import seed.Log
+import seed.cli.util.BloopCli
+import seed.generation.util.{ProjectGeneration, TestProcessHelper}
+import seed.model.{BuildEvent, Platform}
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.{Future, Promise}
+
+object LinkSpec extends SimpleTestSuite {
+  testAsync("Link module and interpret Bloop events") {
+    val projectPath = Paths.get("test/module-link")
+    val build = ProjectGeneration.generateBloopProject(projectPath)
+
+    var events = ListBuffer[BuildEvent]()
+    def onStdOut(output: String): Unit =
+      BloopCli.parseStdOut(build)(output).foreach(events += _)
+
+    val process = Link.link(build, projectPath, List("example" -> None),
+      false, Log, onStdOut)
+    assert(process.isDefined)
+    TestProcessHelper.scheduleTermination(process.get)
+
+    for {
+      code <- process.get.termination
+      _ <- Future {
+        require(process.get.killed || code == 0)
+        require(events.length == 3)
+        require(events(0) == BuildEvent.Compiling("example", Platform.JavaScript))
+        require(events(1) == BuildEvent.Compiled("example", Platform.JavaScript))
+        require(events(2).isInstanceOf[BuildEvent.Linked])
+        require(events(2).asInstanceOf[BuildEvent.Linked]
+          .path.endsWith("test/module-link/build/example.js"))
+      }
+    } yield ()
+  }
+}

--- a/src/test/scala/seed/config/BuildConfigSpec.scala
+++ b/src/test/scala/seed/config/BuildConfigSpec.scala
@@ -6,6 +6,7 @@ import minitest.SimpleTestSuite
 import java.nio.file.Paths
 
 import org.apache.commons.io.FileUtils
+import seed.Log
 import seed.config.util.TomlUtils
 import seed.model.Build
 import seed.model.Build.{Project, ScalaDep, VersionTag}
@@ -22,7 +23,7 @@ object BuildConfigSpec extends SimpleTestSuite {
         |sources = ["src"]
       """.stripMargin, "UTF-8")
 
-    val (projectPath, _) = BuildConfig.load(Paths.get("/tmp/a.toml"))
+    val (projectPath, _) = BuildConfig.load(Paths.get("/tmp/a.toml"), Log).get
     assertEquals(projectPath, Paths.get("/tmp"))
   }
 
@@ -36,7 +37,7 @@ object BuildConfigSpec extends SimpleTestSuite {
         |sources = ["src"]
       """.stripMargin, "UTF-8")
 
-    val (projectPath, _) = BuildConfig.load(Paths.get("test/a.toml"))
+    val (projectPath, _) = BuildConfig.load(Paths.get("test/a.toml"), Log).get
     assertEquals(projectPath, Paths.get("test"))
   }
 
@@ -65,7 +66,7 @@ object BuildConfigSpec extends SimpleTestSuite {
 
     val buildRaw = TomlUtils.parseBuildToml(Paths.get("."))(toml)
     val build = BuildConfig.processBuild(buildRaw.right.get, _ =>
-      Build(project = Project(scalaVersion = "2.12.8"), module = Map()))
+      Some(Build(project = Project(scalaVersion = "2.12.8"), module = Map())))
 
     assertEquals(
       build.module("example").test.get.targets,
@@ -86,7 +87,7 @@ object BuildConfigSpec extends SimpleTestSuite {
 
     val buildRaw = TomlUtils.parseBuildToml(Paths.get("."))(toml)
     val build = BuildConfig.processBuild(buildRaw.right.get, _ =>
-      Build(project = Project(scalaVersion = "2.12.8"), module = Map()))
+      Some(Build(project = Project(scalaVersion = "2.12.8"), module = Map())))
 
     assertEquals(
       build.module("example").jvm.get.scalaDeps,

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -2,18 +2,23 @@ package seed.generation
 
 import java.nio.file.{Files, Path, Paths}
 
-import minitest.SimpleTestSuite
+import minitest.TestSuite
 import org.apache.commons.io.FileUtils
 import seed.{Log, cli}
 import seed.Cli.{Command, PackageConfig}
 import seed.config.BuildConfig
 import seed.generation.util.TestProcessHelper
+import seed.generation.util.TestProcessHelper.ec
 import seed.model.Config
 
-import scala.concurrent.ExecutionContext.Implicits._
+object BloopIntegrationSpec extends TestSuite[Unit] {
+  override def setupSuite(): Unit = TestProcessHelper.semaphore.acquire()
+  override def tearDownSuite(): Unit = TestProcessHelper.semaphore.release()
 
-object BloopIntegrationSpec extends SimpleTestSuite {
-  testAsync("Generate and compile meta modules") {
+  override def setup(): Unit = ()
+  override def tearDown(env: Unit): Unit = ()
+
+  testAsync("Generate and compile meta modules") { _ =>
     val projectPath = Paths.get("test/meta-module")
     util.ProjectGeneration.generateBloopProject(projectPath)
     compileAndRun(projectPath)
@@ -35,7 +40,7 @@ object BloopIntegrationSpec extends SimpleTestSuite {
     for { _ <- compile; _ <- run } yield ()
   }
 
-  testAsync("Build project with compiler plug-in") {
+  testAsync("Build project with compiler plug-in") { _ =>
     val (projectPath, build) = BuildConfig.load(
       Paths.get("test/example-paradise"), Log).get
     val buildPath = projectPath.resolve("build")

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -4,75 +4,30 @@ import java.nio.file.{Files, Path, Paths}
 
 import minitest.SimpleTestSuite
 import org.apache.commons.io.FileUtils
-import seed.cli
+import seed.{Log, cli}
 import seed.Cli.{Command, PackageConfig}
-import seed.artefact.{ArtefactResolution, Coursier}
 import seed.config.BuildConfig
-import seed.generation.util.ProcessHelper
-import seed.model.{Build, Config, Platform}
+import seed.generation.util.TestProcessHelper
+import seed.model.Config
 
 import scala.concurrent.ExecutionContext.Implicits._
 
 object BloopIntegrationSpec extends SimpleTestSuite {
   testAsync("Generate and compile meta modules") {
     val projectPath = Paths.get("test/meta-module")
-    if (Files.exists(projectPath)) FileUtils.deleteDirectory(projectPath.toFile)
-
-    val bloopPath = projectPath.resolve(".bloop")
-    val buildPath = projectPath.resolve("build")
-    val sourcePath = projectPath.resolve("src")
-
-    Set(bloopPath, buildPath, sourcePath)
-      .foreach(Files.createDirectories(_))
-
-    val build = Build(
-      project = Build.Project(
-        "2.12.8", scalaJsVersion = Some("0.6.26")),
-      module = Map("example" -> Build.Module(
-        sources = List(sourcePath),
-        targets = List(Platform.JVM, Platform.JavaScript))))
-
-    val resolvedIvyPath = Coursier.DefaultIvyPath
-    val resolvedCachePath = Coursier.DefaultCachePath
-
-    val compilerDeps0 = ArtefactResolution.allCompilerDeps(build)
-    val platformDeps = ArtefactResolution.allPlatformDeps(build)
-    val libraryDeps  = ArtefactResolution.allLibraryDeps(build)
-
-    val resolution =
-      Coursier.resolveAndDownload(platformDeps ++ libraryDeps, build.resolvers,
-        resolvedIvyPath, resolvedCachePath, false)
-    val compilerResolution =
-      compilerDeps0.map(d =>
-        Coursier.resolveAndDownload(d, build.resolvers, resolvedIvyPath,
-          resolvedCachePath, false))
-
-    Bloop.buildModule(
-      projectPath,
-      bloopPath,
-      buildPath,
-      build,
-      resolution,
-      compilerResolution,
-      build.module.keys.head,
-      build.module.values.head)
-
-    FileUtils.write(sourcePath.resolve("Main.scala").toFile,
-      """object Main extends App { println("hello") }""",
-      "UTF-8")
-
+    util.ProjectGeneration.generateBloopProject(projectPath)
     compileAndRun(projectPath)
   }
 
   def compileAndRun(projectPath: Path) = {
     def compile =
-      ProcessHelper.runBloop(projectPath)("compile", "example").map { x =>
+      TestProcessHelper.runBloop(projectPath)("compile", "example").map { x =>
         assertEquals(x.contains("Compiled example-jvm"), true)
         assertEquals(x.contains("Compiled example-js"), true)
       }
 
     def run =
-      ProcessHelper.runBloop(projectPath)("run", "example-js", "example-jvm")
+      TestProcessHelper.runBloop(projectPath)("run", "example-js", "example-jvm")
         .map { x =>
           assertEquals(x.split("\n").count(_ == "hello"), 2)
         }
@@ -82,7 +37,7 @@ object BloopIntegrationSpec extends SimpleTestSuite {
 
   testAsync("Build project with compiler plug-in") {
     val (projectPath, build) = BuildConfig.load(
-      Paths.get("test/example-paradise"))
+      Paths.get("test/example-paradise"), Log).get
     val buildPath = projectPath.resolve("build")
     if (Files.exists(buildPath)) FileUtils.deleteDirectory(buildPath.toFile)
     val packageConfig = PackageConfig(tmpfs = false, silent = false,

--- a/src/test/scala/seed/generation/util/ProjectGeneration.scala
+++ b/src/test/scala/seed/generation/util/ProjectGeneration.scala
@@ -1,0 +1,60 @@
+package seed.generation.util
+
+import java.nio.file.{Files, Path}
+
+import org.apache.commons.io.FileUtils
+import seed.artefact.{ArtefactResolution, Coursier}
+import seed.generation.Bloop
+import seed.model.{Build, Platform}
+
+object ProjectGeneration {
+  /** Generate project compiling to JavaScript and JVM */
+  def generateBloopProject(projectPath: Path): Build = {
+    if (Files.exists(projectPath)) FileUtils.deleteDirectory(projectPath.toFile)
+
+    val bloopPath = projectPath.resolve(".bloop")
+    val buildPath = projectPath.resolve("build")
+    val sourcePath = projectPath.resolve("src")
+
+    Set(bloopPath, buildPath, sourcePath)
+      .foreach(Files.createDirectories(_))
+
+    val build = Build(
+      project = Build.Project(
+        "2.12.8", scalaJsVersion = Some("0.6.26")),
+      module = Map("example" -> Build.Module(
+        sources = List(sourcePath),
+        targets = List(Platform.JVM, Platform.JavaScript))))
+
+    val resolvedIvyPath = Coursier.DefaultIvyPath
+    val resolvedCachePath = Coursier.DefaultCachePath
+
+    val compilerDeps0 = ArtefactResolution.allCompilerDeps(build)
+    val platformDeps = ArtefactResolution.allPlatformDeps(build)
+    val libraryDeps  = ArtefactResolution.allLibraryDeps(build)
+
+    val resolution =
+      Coursier.resolveAndDownload(platformDeps ++ libraryDeps, build.resolvers,
+        resolvedIvyPath, resolvedCachePath, false)
+    val compilerResolution =
+      compilerDeps0.map(d =>
+        Coursier.resolveAndDownload(d, build.resolvers, resolvedIvyPath,
+          resolvedCachePath, false))
+
+    Bloop.buildModule(
+      projectPath,
+      bloopPath,
+      buildPath,
+      build,
+      resolution,
+      compilerResolution,
+      build.module.keys.head,
+      build.module.values.head)
+
+    FileUtils.write(sourcePath.resolve("Main.scala").toFile,
+      """object Main extends App { println("hello") }""",
+      "UTF-8")
+
+    build
+  }
+}

--- a/src/test/scala/seed/generation/util/TestProcessHelper.scala
+++ b/src/test/scala/seed/generation/util/TestProcessHelper.scala
@@ -1,0 +1,42 @@
+package seed.generation.util
+
+import java.nio.file.Path
+import java.util.concurrent.{Executors, TimeUnit}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits._
+
+import seed.Log
+import seed.process.ProcessHelper
+
+object TestProcessHelper {
+  val scheduler = Executors.newScheduledThreadPool(1)
+  def schedule(seconds: Int)(f: => Unit): Unit =
+    scheduler.schedule({ () => f }: Runnable, seconds, TimeUnit.SECONDS)
+
+  /**
+    * Work around a CI problem where onExit() does not get called on
+    * [[seed.process.ProcessHandler]].
+    */
+  def scheduleTermination(process: ProcessHelper.Process): Unit =
+    TestProcessHelper.schedule(60) {
+      if (process.isRunning) {
+        Log.error(s"Process did not terminate after 60s")
+        Log.error("Forcing termination...")
+        process.kill()
+      }
+    }
+
+  def runBloop(cwd: Path, silent: Boolean = false)
+              (args: String*): Future[String] = {
+    val sb = new StringBuilder
+    val process = ProcessHelper.runBloop(cwd, silent,
+      out => sb.append(out + "\n"))(args: _*)
+    scheduleTermination(process)
+
+    process.termination.flatMap { statusCode =>
+      if (process.killed || statusCode == 0) Future.successful(sb.toString)
+      else Future.failed(new Exception("Status code: " + statusCode))
+    }
+  }
+}


### PR DESCRIPTION
- `Cli`: Add new commands `server`, `link` and `buildEvents`
- `Log`: Make underlying printer customisable
- `BuildConfig`: Take `Log` parameter to allow forwarding of log messages
- `BuildConfig`, `TomlUtils`: Gracefully handle errors instead of exiting program
- `BuildConfig`: Add `linkTargets()` to determine all possible link targets of a module
- `ArgyleHelpers`: Introduce Argyle parser for flags that take an optional value
- `BloopCli`: Introduce helper object for interacting with Bloop and parsing its output
- `WsServer`: Introduce WebSocket server based on Java WebSockets
- `WsCommand`: Define JSON protocol for WebSocket server including Circe codecs
- `BloopIntegrationSpec`: Move project generation logic to `ProjectGeneration` for better reuse