### PR TITLE
Honour Scala version mandated by modules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -x
-curl -o csbt https://raw.githubusercontent.com/coursier/sbt-launcher/master/csbt
+curl -L -o csbt https://github.com/coursier/sbt-launcher/releases/download/v1.2.5/csbt
 chmod +x csbt
 ./csbt compile || \
 	 ./csbt compile || \

--- a/src/main/scala/seed/artefact/ArtefactResolution.scala
+++ b/src/main/scala/seed/artefact/ArtefactResolution.scala
@@ -209,6 +209,10 @@ object ArtefactResolution {
       .groupBy(_._1)
       .mapValues(_.map(_._2))
 
+  def isCompilerLibrary(library: Path): Boolean =
+    library.toString.contains("/scala-library/") ||
+    library.toString.contains("/scala-reflect/")
+
   def resolveScalaCompiler(resolutionResult: List[Coursier.ResolutionResult],
                            scalaOrganisation: String,
                            scalaVersion: String,
@@ -228,14 +232,10 @@ object ArtefactResolution {
     // Replace official scala-library and scala-reflect artefacts by
     // organisation-specific ones. This is needed for Typelevel Scala.
     val fullClassPath = libraries.map(_.libraryJar) ++
-                        classPath
-                          .filter(!_.toString.contains("/scala-library/"))
-                          .filter(!_.toString.contains("/scala-reflect/"))
+                        classPath.filter(!isCompilerLibrary(_))
 
     val compilerJars: List[Path] =
-      compiler.map(_.libraryJar)
-        .filter(!_.toString.contains("/scala-library/"))
-        .filter(!_.toString.contains("/scala-reflect/")) ++
+      compiler.map(_.libraryJar).filter(!isCompilerLibrary(_)) ++
       libraries.map(_.libraryJar)
 
     Resolution.ScalaCompiler(

--- a/src/main/scala/seed/generation/Bloop.scala
+++ b/src/main/scala/seed/generation/Bloop.scala
@@ -109,7 +109,7 @@ object Bloop {
             scalaJsVersion.get, scalaVersion, scalaJsVersion.get).get
 
         val plugIns = util.ScalaCompiler.compilerPlugIns(build,
-          parentModule, compilerResolution, JavaScript)
+          parentModule, compilerResolution, JavaScript, scalaVersion)
 
         val resolvedDeps = Coursier.localArtefacts(
           resolution,
@@ -216,7 +216,7 @@ object Bloop {
         ).toMap
 
         val plugIns = util.ScalaCompiler.compilerPlugIns(build,
-          parentModule, compilerResolution, Native)
+          parentModule, compilerResolution, Native, scalaVersion)
 
         val resolvedDeps =
           Coursier.localArtefacts(resolution,
@@ -311,7 +311,7 @@ object Bloop {
           (javaDeps ++ scalaDeps).toSet)
 
         val plugIns = util.ScalaCompiler.compilerPlugIns(build,
-          parentModule, compilerResolution, JVM)
+          parentModule, compilerResolution, JVM, scalaVersion)
 
         val dependencies = if (test) List(name)
                            else (moduleDeps ++ jvm.moduleDeps).map(name => BuildConfig.targetName(build, name, JVM))

--- a/src/main/scala/seed/generation/util/ScalaCompiler.scala
+++ b/src/main/scala/seed/generation/util/ScalaCompiler.scala
@@ -13,10 +13,10 @@ object ScalaCompiler {
                       module: Module,
                       compilerResolution: List[Coursier.ResolutionResult],
                       artefact: Artefact,
-                      platform: Platform
+                      platform: Platform,
+                      compilerVer: String
                      ): Path = {
     val platformVer = BuildConfig.platformVersion(build, module, platform)
-    val compilerVer = BuildConfig.scalaVersion(build.project, List(module))
 
     compilerResolution.iterator.flatMap(resolution =>
       Coursier.artefactPath(resolution, artefact, platform,
@@ -28,7 +28,8 @@ object ScalaCompiler {
   def compilerPlugIns(build: Build,
                       module: Module,
                       compilerResolution: List[Coursier.ResolutionResult],
-                      platform: Platform): List[String] = {
+                      platform: Platform,
+                      compilerVer: String): List[String] = {
     val moduleDeps = BuildConfig.collectModuleDeps(build, module, platform)
     val modules = moduleDeps.map(build.module) :+ module
     val artefacts =
@@ -38,7 +39,7 @@ object ScalaCompiler {
       ) ++ modules.flatMap(_.compilerDeps.map(Artefact.fromDep))
 
     artefacts.map(a => resolveCompiler(
-      build, module, compilerResolution, a, platform)
+      build, module, compilerResolution, a, platform, compilerVer)
     ).map(p => "-Xplugin:" + p)
   }
 }

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -1,14 +1,16 @@
 package seed.generation
 
 import minitest.SimpleTestSuite
-
 import java.nio.file.Paths
 
-import seed.Cli.PackageConfig
+import org.apache.commons.io.FileUtils
+import seed.Cli.{Command, PackageConfig}
+import seed.{Log, cli}
 import seed.artefact.ArtefactResolution
+import seed.config.BuildConfig
 import seed.model.Build.{Module, Project}
 import seed.model.Platform.JVM
-import seed.model.Build
+import seed.model.{Build, Config}
 
 object IdeaSpec extends SimpleTestSuite {
   test("Normalise paths") {
@@ -52,5 +54,66 @@ object IdeaSpec extends SimpleTestSuite {
 
     Idea.build(projectPath, outputPath, build, platformResolution,
       compilerResolution, false)
+  }
+
+  test("Generate project with custom compiler options") {
+    val (projectPath, build) = BuildConfig.load(
+      Paths.get("test/compiler-options"), Log).get
+    val packageConfig = PackageConfig(tmpfs = false, silent = false,
+      ivyPath = None, cachePath = None)
+    cli.Build.ui(Config(), projectPath, build, Command.Idea(packageConfig))
+
+    val ideaPath = projectPath.resolve(".idea")
+
+    val scalaCompiler =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("scala_compiler.xml").toFile, "UTF-8"))
+
+    val profileNodes = scalaCompiler.byTagAll["profile"]
+    assertEquals(profileNodes.length, 1)
+    assertEquals(profileNodes.head.attr("modules"),
+      Some("demo,demo-jvm,demo-js"))
+    assertEquals(
+      profileNodes.head.byTag["parameter"].attr("value"),
+      Some("-Yliteral-types"))
+  }
+
+  test("Generate project with different Scala versions") {
+    val (projectPath, build) = BuildConfig.load(
+      Paths.get("test/multiple-scala-versions"), Log).get
+    val packageConfig = PackageConfig(tmpfs = false, silent = false,
+      ivyPath = None, cachePath = None)
+    cli.Build.ui(Config(), projectPath, build, Command.Idea(packageConfig))
+
+    val ideaPath = projectPath.resolve(".idea")
+
+    val scalaCompiler =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("scala_compiler.xml").toFile, "UTF-8"))
+
+    val profileNodes = scalaCompiler.byTagAll["profile"]
+    assertEquals(profileNodes.length, 1)
+    assertEquals(profileNodes.head.attr("modules"),
+      Some("module212,module211"))
+
+    val module211 =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("modules").resolve("module211.iml").toFile,
+        "UTF-8"))
+    val libraries211 = module211.byTagAll["orderEntry"]
+      .filter(_.attr("type").contains("library"))
+      .flatMap(_.attr("name"))
+    assertEquals(libraries211,
+      List("org.scala-lang-2.11.11", "sourcecode_2.11-0.1.5.jar"))
+
+    val module212 =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("modules").resolve("module212.iml").toFile,
+        "UTF-8"))
+    val libraries212 = module212.byTagAll["orderEntry"]
+      .filter(_.attr("type").contains("library"))
+      .flatMap(_.attr("name"))
+    assertEquals(libraries212,
+      List("org.scala-lang-2.12.8", "sourcecode_2.12-0.1.5.jar"))
   }
 }

--- a/test/compiler-options/build.toml
+++ b/test/compiler-options/build.toml
@@ -1,0 +1,17 @@
+[project]
+scalaVersion      = "2.12.4-bin-typelevel-4"
+scalaJsVersion    = "0.6.26"
+scalaOrganisation = "org.typelevel"
+scalaOptions      = ["-Yliteral-types"]
+
+[module.demo]
+root    = "shared"
+sources = ["shared/src/"]
+
+[module.demo.jvm]
+root    = "jvm"
+sources = ["jvm/src/"]
+
+[module.demo.js]
+root    = "js"
+sources = ["js/src/"]

--- a/test/multiple-scala-versions/build.toml
+++ b/test/multiple-scala-versions/build.toml
@@ -1,0 +1,13 @@
+[project]
+scalaVersion = "2.12.8"
+
+[module.module212.jvm]
+root = "module212"
+sources = ["module212/src"]
+scalaDeps = [["com.lihaoyi", "sourcecode", "0.1.5"]]
+
+[module.module211.jvm]
+scalaVersion = "2.11.11"
+root = "module211"
+sources = ["module211/src"]
+scalaDeps = [["com.lihaoyi", "sourcecode", "0.1.5"]]

--- a/test/multiple-scala-versions/module211/src/Main.scala
+++ b/test/multiple-scala-versions/module211/src/Main.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  println(implicitly[sourcecode.Name].value)
+  println(util.Properties.versionNumberString)
+}

--- a/test/multiple-scala-versions/module212/src/Main.scala
+++ b/test/multiple-scala-versions/module212/src/Main.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  println(implicitly[sourcecode.Name].value)
+  println(util.Properties.versionNumberString)
+}


### PR DESCRIPTION
- **Bloop:** When determining the class path for compiler plug-ins, use the Scala version of the module instead of the global compiler version
- **IDEA:** Generate modules with the correct Scala version and compiler options