### PR TITLE
Drone CI: Only publish when pushing to master or releasing a version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,28 @@ steps:
       - blp-server &
       - ./build.sh
       - ./csbt test
-  - name: publish
+  - name: publish_prerelease
+    image: plugins/docker
+    environment:
+      BINTRAY_USERNAME:
+        from_secret: bintray_username
+      BINTRAY_API:
+        from_secret: bintray_api
+    settings:
+      repo: tindzk/seed
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      build_args_from_env:
+        - BINTRAY_USERNAME
+        - BINTRAY_API
+    when:
+      branch:
+        - master
+      event:
+        - push
+  - name: publish_release
     image: plugins/docker
     environment:
       BINTRAY_USERNAME:
@@ -37,11 +58,7 @@ steps:
         - BINTRAY_API
     when:
       event:
-        include:
-          - push
-          - tag
-        exclude:
-          - pull_request
+        - tag
   - name: benchmarks
     image: tindzk/seed:latest
     pull: always


### PR DESCRIPTION
Since `branch` cannot be used in conjunction with `event: tag`,
create two separate CI steps, one for publishing pre-releases (i.e.
any push to `master`) and another for releases (i.e. any tagged
commit).

See also 5f48fa5.