### PR TITLE
Bloop: Inherit javaDeps from parent modules

### DIFF
--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -22,7 +22,7 @@ object LinkSpec extends TestSuite[Unit] {
 
   testAsync("Link module and interpret Bloop events") { _ =>
     val projectPath = Paths.get("test/module-link")
-    val build = ProjectGeneration.generateBloopProject(projectPath)
+    val build = ProjectGeneration.generateBloopCrossProject(projectPath)
 
     var events = ListBuffer[BuildEvent]()
     def onStdOut(output: String): Unit =

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -36,7 +36,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
   testAsync("Generate and compile meta modules") { _ =>
     val projectPath = Paths.get("test/meta-module")
-    util.ProjectGeneration.generateBloopProject(projectPath)
+    util.ProjectGeneration.generateBloopCrossProject(projectPath)
     compileAndRun(projectPath)
   }
 

--- a/src/test/scala/seed/generation/BloopSpec.scala
+++ b/src/test/scala/seed/generation/BloopSpec.scala
@@ -1,0 +1,29 @@
+package seed.generation
+
+import java.nio.file.{Path, Paths}
+
+import bloop.config.ConfigEncoderDecoders
+import minitest.SimpleTestSuite
+import org.apache.commons.io.FileUtils
+
+object BloopSpec extends SimpleTestSuite {
+  def parseBloopFile(path: Path): bloop.config.Config.File = {
+    val json = FileUtils.readFileToString(path.toFile, "UTF-8")
+    io.circe.parser.decode(json)(ConfigEncoderDecoders.allDecoder).right.get
+  }
+
+  test("Inherit javaDeps in child modules") {
+    val projectPath = Paths.get("test/inherit-javadeps")
+    val bloopPath = projectPath.resolve(".bloop")
+    util.ProjectGeneration.generateJavaDepBloopProject(projectPath)
+
+    val base = parseBloopFile(bloopPath.resolve("base.json"))
+    assert(base.project.classpath.exists(_.toString.contains("/org/postgresql/postgresql/")))
+
+    val example = parseBloopFile(bloopPath.resolve("example.json"))
+    assert(example.project.classpath.exists(_.toString.contains("/org/postgresql/postgresql/")))
+
+    val exampleTest = parseBloopFile(bloopPath.resolve("example-test.json"))
+    assert(exampleTest.project.classpath.exists(_.toString.contains("/org/postgresql/postgresql/")))
+  }
+}


### PR DESCRIPTION
When generating a Bloop project, Java dependencies specified on base
modules should be inherited and added to the class path of all child
modules. These changes make the behaviour of `javaDeps` consistent
with `scalaDeps`.