### PR TITLE
IDEA: Set language level for Scala library

### DIFF
--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -31,8 +31,7 @@ object Idea {
                    ): Unit = {
     val xml = IdeaFile.createLibrary(IdeaFile.Library(
       libraryJar.getFileName.toString,
-      isScalaCompiler = false,
-      compilerClasses = List(),
+      compilerInfo = None,
       classes = List(libraryJar.toAbsolutePath.toString),
       javaDoc = javaDocJar.toList.map(_.toAbsolutePath.toString),
       sources = sourcesJar.toList.map(_.toAbsolutePath.toString)))
@@ -122,8 +121,8 @@ object Idea {
 
       val xml = IdeaFile.createLibrary(IdeaFile.Library(
         name = build.project.scalaOrganisation + "-" + scalaVersion,
-        isScalaCompiler = true,
-        compilerClasses = scalaCompiler.compilerJars.map(_.toString),
+        compilerInfo = Some(IdeaFile.CompilerInfo(
+          scalaVersion, scalaCompiler.compilerJars.map(_.toString))),
         classes = scalaCompiler.fullClassPath.map(_.toString),
         javaDoc = List(),
         sources = List()))

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -108,6 +108,19 @@ object IdeaSpec extends SimpleTestSuite {
     assertEquals(profileNodes.head.attr("modules"),
       Some("module212,module211"))
 
+    val scalaLibrary2_11_11 =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("libraries").resolve("org_scala_lang_2_11_11.xml").toFile,
+        "UTF-8"))
+    val scalaLibrary2_12_8 =
+      pine.XmlParser.fromString(FileUtils.readFileToString(
+        ideaPath.resolve("libraries").resolve("org_scala_lang_2_12_8.xml").toFile,
+        "UTF-8"))
+    assertEquals(scalaLibrary2_11_11.byTagAll["language-level"].map(_.toText),
+      List("Scala_2_11"))
+    assertEquals(scalaLibrary2_12_8.byTagAll["language-level"].map(_.toText),
+      List("Scala_2_12"))
+
     val module211 =
       pine.XmlParser.fromString(FileUtils.readFileToString(
         ideaPath.resolve("modules").resolve("module211.iml").toFile,


### PR DESCRIPTION
This setting is required for IDEA to know whether certain
version-specific features are available (such as literal types in
2.13).