### PR TITLE
Refactor build path logic

### DIFF
--- a/src/main/scala/seed/Cli.scala
+++ b/src/main/scala/seed/Cli.scala
@@ -156,8 +156,8 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
     ${italic("link")}          Link module(s)
     ${italic("buildEvents")}   Subscribe to build events on Seed server
     ${italic("update")}        Check library dependencies for updates
-    ${italic("package")}       Create JAR package for given module and its dependent modules
-                  Also sets the main class from the configuration file
+    ${italic("package")}       Create JAR package for given module and its dependencies
+                  Also sets the main class from the build file
                   Specify --libs to copy all library dependencies for distribution
 
   ${bold("Parameters:")}
@@ -176,7 +176,7 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
   ${bold("Command:")} ${underlined("build")} [--connect[=${webSocketDefaultConnection.format}]] [--watch] [--tmpfs] <modules>
     ${italic("--connect")}     Run build command on remote Seed server
     ${italic("--watch")}       Build upon source changes (cannot be combined with ${Ansi.italic("--connect")})
-    ${italic("<modules>")}     One or multiple space-separated modules. The syntax of a module is: ${italic("<name>")} or ${italic("<name>:<platform>")}
+    ${italic("<modules>")}     One or multiple space-separated modules. The syntax of a module is: ${italic("<name>")} or ${italic("<name>:<target>")}
                   ${italic("Examples:")}
                   - app          Compile all available platforms of module ${Ansi.italic("app")}
                   - app:js       Only compile JavaScript platform of module ${Ansi.italic("app")}
@@ -205,8 +205,8 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
 
   ${bold("Command:")} ${underlined("package")} [--tmpfs] [--libs] [--output=<path>] <module>
     ${italic("--tmpfs")}       Read build directory in tmpfs
-    ${italic("--libs")}        Copy libraries and reference them in the JAR's class path.
-    ${italic("--output")}      Output path (default: ${Ansi.italic("dist/")})
+    ${italic("--libs")}        Copy libraries and reference them in the JAR's class path
+    ${italic("--output")}      Output path (default: ${Ansi.italic("build/dist/")})
     ${italic("<module>")}      Module to package""")
   }
 

--- a/src/main/scala/seed/cli/BuildTarget.scala
+++ b/src/main/scala/seed/cli/BuildTarget.scala
@@ -1,15 +1,15 @@
 package seed.cli
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 
 import seed.Log
 import seed.config.BuildConfig
+import seed.generation.util.PathUtil
 import seed.model
 import seed.process.ProcessHelper
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object BuildTarget {
@@ -46,9 +46,7 @@ object BuildTarget {
 
     val allTargets = (targets ++ inheritedTargets).distinct
 
-    val buildPath =
-      if (tmpfs) BuildConfig.tmpfsPath(projectPath, log).resolve("bloop")
-      else Paths.get("build")
+    val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
 
     log.info(s"Build path: $buildPath")
 

--- a/src/main/scala/seed/config/BuildConfig.scala
+++ b/src/main/scala/seed/config/BuildConfig.scala
@@ -290,11 +290,4 @@ object BuildConfig {
   def collectJvmJavaDeps(build: Build, module: Module): List[JavaDep] =
     module.javaDeps ++ module.jvm.map(_.javaDeps).getOrElse(List()) ++
     jvmModuleDeps(module).flatMap(m => collectJvmJavaDeps(build, build.module(m)))
-
-  def tmpfsPath(projectPath: Path, log: Log = Log): Path = {
-    val name = projectPath.toAbsolutePath.getFileName.toString
-    log.info("Build path set to tmpfs")
-    log.warn(s"Please ensure that there is no other project with the name ${Ansi.italic(name)} that also compiles to tmpfs")
-    Paths.get("/tmp").resolve("build-" + name)
-  }
 }

--- a/src/main/scala/seed/generation/util/PathUtil.scala
+++ b/src/main/scala/seed/generation/util/PathUtil.scala
@@ -1,0 +1,34 @@
+package seed.generation.util
+
+import java.nio.file.{Path, Paths}
+
+import seed.Log
+import seed.cli.util.Ansi
+
+object PathUtil {
+  def tmpfsPath(projectPath: Path, log: Log = Log): Path = {
+    val name = projectPath.toAbsolutePath.getFileName.toString
+    log.info("Build path set to tmpfs")
+    log.warn(s"Please ensure that there is no other project with the name ${Ansi.italic(name)} that also compiles to tmpfs")
+    Paths.get("/tmp").resolve("build-" + name)
+  }
+
+  def buildPath(projectPath: Path, tmpfs: Boolean, log: Log = Log): Path =
+    if (tmpfs) tmpfsPath(projectPath) else projectPath.resolve("build")
+
+  def normalisePath(pathVariable: String, root: Path)(path: Path): String = {
+    val canonicalRoot = root.toFile.getCanonicalPath
+    val canonicalPath = path.toFile.getCanonicalPath
+
+    val rootElems = canonicalRoot.split("/").toList
+    val pathElems = canonicalPath.split("/").toList
+    val common = pathElems.zip(rootElems).takeWhile { case (a, b) => a == b }
+
+    if (common.length == 1) canonicalPath
+    else {
+      val levels = rootElems.length - common.length
+      val relativePath = (0 until levels).map(_ => "../").mkString
+      pathVariable + "/" + relativePath + pathElems.drop(common.length).mkString("/")
+    }
+  }
+}

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -8,6 +8,7 @@ import seed.Cli.{Command, PackageConfig}
 import seed.{Log, cli}
 import seed.artefact.ArtefactResolution
 import seed.config.BuildConfig
+import seed.generation.util.PathUtil
 import seed.model.Build.{Module, Project}
 import seed.model.Platform.JVM
 import seed.model.{Build, Config}
@@ -15,16 +16,16 @@ import seed.model.{Build, Config}
 object IdeaSpec extends SimpleTestSuite {
   test("Normalise paths") {
     assertEquals(
-      Idea.normalisePath(Idea.ModuleDir, Paths.get("/tmp"))(Paths.get("/tmp")),
+      PathUtil.normalisePath(Idea.ModuleDir, Paths.get("/tmp"))(Paths.get("/tmp")),
       "$MODULE_DIR$/")
 
     assertEquals(
-      Idea.normalisePath(Idea.ModuleDir, Paths.get("/tmp/.idea/modules"))(
+      PathUtil.normalisePath(Idea.ModuleDir, Paths.get("/tmp/.idea/modules"))(
         Paths.get("/tmp/src")
       ), "$MODULE_DIR$/../../src")
 
     assertEquals(
-      Idea.normalisePath(Idea.ModuleDir, Paths.get(".idea/modules"))(Paths.get("/tmp/build")),
+      PathUtil.normalisePath(Idea.ModuleDir, Paths.get(".idea/modules"))(Paths.get("/tmp/build")),
       "/tmp/build")
   }
 

--- a/src/test/scala/seed/generation/util/PathUtilSpec.scala
+++ b/src/test/scala/seed/generation/util/PathUtilSpec.scala
@@ -1,0 +1,18 @@
+package seed.generation.util
+
+import java.nio.file.Paths
+
+import minitest.SimpleTestSuite
+
+object PathUtilSpec extends SimpleTestSuite {
+  test("Default build paths") {
+    val projectPath = Paths.get("test/compiler-options")
+
+    assertEquals(
+      PathUtil.buildPath(projectPath, tmpfs = false),
+      Paths.get("test/compiler-options/build"))
+    assertEquals(
+      PathUtil.buildPath(projectPath, tmpfs = true),
+      Paths.get("/tmp/build-compiler-options"))
+  }
+}

--- a/src/test/scala/seed/generation/util/ProjectGeneration.scala
+++ b/src/test/scala/seed/generation/util/ProjectGeneration.scala
@@ -14,8 +14,10 @@ object ProjectGeneration {
 
     val bloopPath = projectPath.resolve(".bloop")
     val buildPath = projectPath.resolve("build")
+    val bloopBuildPath = buildPath.resolve("bloop")
 
-    Set(bloopPath, buildPath).foreach(Files.createDirectories(_))
+    Set(bloopPath, buildPath, bloopBuildPath)
+      .foreach(Files.createDirectories(_))
 
     val resolvedIvyPath = Coursier.DefaultIvyPath
     val resolvedCachePath = Coursier.DefaultCachePath
@@ -38,6 +40,7 @@ object ProjectGeneration {
         projectPath,
         bloopPath,
         buildPath,
+        bloopBuildPath,
         build,
         resolution,
         compilerResolution,


### PR DESCRIPTION
Currently, if tmpfs is disabled, `BuildTarget` uses an output path
that is different from the generated Bloop project. Introduce
`PathUtil` to unify the build path logic across the entire code base
and write test cases.

Also, change the path of the linked Bloop artefacts from
`build/bloop/` to `build/`. When packaging modules, place `dist/`
under the same build path.

Further changes:
- Idea: Move `normalisePath()` to `PathUtil`
- `Cli`: Improve help