### PR TITLE
ProcessHelper: Exit when command returned with non-zero code

### DIFF
--- a/src/main/scala/seed/Log.scala
+++ b/src/main/scala/seed/Log.scala
@@ -3,18 +3,20 @@ package seed
 import seed.cli.util.Ansi._
 import seed.cli.util.ColourScheme._
 
-class Log(f: String => Unit) {
+class Log(f: String => Unit, map: String => String = identity) {
+  def prefix(text: String): Log = new Log(f, text + _)
+
   def error(message: String): Unit =
-    f(foreground(red2)(bold("[error]") + " " + message))
+    f(foreground(red2)(bold("[error]") + " " + map(message)))
 
   def warn(message: String): Unit =
-    f(foreground(yellow2)(bold("[warn]") + " " + message))
+    f(foreground(yellow2)(bold("[warn]") + "  " + map(message)))
 
   def debug(message: String): Unit =
-    f(foreground(green2)(bold("[debug]") + " " + message))
+    f(foreground(green2)(bold("[debug]") + " " + map(message)))
 
   def info(message: String): Unit =
-    f(foreground(blue2)(bold("[info]") + " " + message))
+    f(foreground(blue2)(bold("[info]") + "  " + map(message)))
 }
 
-object Log extends Log(println)
+object Log extends Log(println, identity)

--- a/src/main/scala/seed/cli/Build.scala
+++ b/src/main/scala/seed/cli/Build.scala
@@ -68,7 +68,7 @@ object Build {
 
           val bloop = util.BloopCli.compile(
             build, projectPath, buildModules, watch, log, onStdOut(build)
-          ).fold(Future.unit)(_.termination.map(_ => ()))
+          ).fold(Future.unit)(_.success)
 
           Future.sequence(futures :+ bloop).map(_ => ())
         }

--- a/src/main/scala/seed/cli/Link.scala
+++ b/src/main/scala/seed/cli/Link.scala
@@ -69,7 +69,7 @@ object Link {
 
           val bloop = util.BloopCli.link(
             build, projectPath, linkModules, watch, log, onStdOut(build)
-          ).fold(Future.unit)(_.termination.map(_ => ()))
+          ).fold(Future.unit)(_.success)
 
           Future.sequence(futures :+ bloop).map(_ => ())
         }

--- a/src/main/scala/seed/cli/util/BloopCli.scala
+++ b/src/main/scala/seed/cli/util/BloopCli.scala
@@ -58,7 +58,7 @@ object BloopCli {
     if (bloopModules.isEmpty) None
     else {
       val args = "compile" +: ((if (!watch) List() else List("--watch")) ++ bloopModules)
-      Some(ProcessHelper.runBloop(projectPath, onStdOut)(args: _*))
+      Some(ProcessHelper.runBloop(projectPath, log, onStdOut)(args: _*))
     }
 
   def link(build: Build,
@@ -71,6 +71,6 @@ object BloopCli {
     if (bloopModules.isEmpty) None
     else {
       val args = "link" +: ((if (!watch) List() else List("--watch")) ++ bloopModules)
-      Some(ProcessHelper.runBloop(projectPath, onStdOut)(args: _*))
+      Some(ProcessHelper.runBloop(projectPath, log, onStdOut)(args: _*))
     }
 }

--- a/src/main/scala/seed/cli/util/Exit.scala
+++ b/src/main/scala/seed/cli/util/Exit.scala
@@ -1,0 +1,10 @@
+package seed.cli.util
+
+object Exit {
+  var TestCases = false
+
+  def error(): Throwable = {
+    if (!TestCases) System.exit(1)
+    new Throwable
+  }
+}

--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -30,19 +30,16 @@ object LinkSpec extends TestSuite[Unit] {
       build, projectPath, List("example-js"), watch = false, Log, onStdOut)
 
     assert(process.isDefined)
-    TestProcessHelper.scheduleTermination(process.get)
 
     for {
-      code <- process.get.termination
-      _ <- Future {
-        require(process.get.killed || code == 0)
-        require(events.length == 3)
-        require(events(0) == BuildEvent.Compiling("example", Platform.JavaScript))
-        require(events(1) == BuildEvent.Compiled("example", Platform.JavaScript))
-        require(events(2).isInstanceOf[BuildEvent.Linked])
-        require(events(2).asInstanceOf[BuildEvent.Linked]
-          .path.endsWith("test/module-link/build/example.js"))
-      }
-    } yield ()
+      _ <- process.get.success
+    } yield {
+      require(events.length == 3)
+      require(events(0) == BuildEvent.Compiling("example", Platform.JavaScript))
+      require(events(1) == BuildEvent.Compiled("example", Platform.JavaScript))
+      require(events(2).isInstanceOf[BuildEvent.Linked])
+      require(events(2).asInstanceOf[BuildEvent.Linked]
+        .path.endsWith("test/module-link/build/example.js"))
+    }
   }
 }

--- a/src/test/scala/seed/generation/util/TestProcessHelper.scala
+++ b/src/test/scala/seed/generation/util/TestProcessHelper.scala
@@ -1,7 +1,7 @@
 package seed.generation.util
 
 import java.nio.file.Path
-import java.util.concurrent.{Executors, Semaphore, TimeUnit}
+import java.util.concurrent.{Executors, Semaphore}
 
 import scala.concurrent.{ExecutionContext, Future}
 import seed.Log
@@ -16,35 +16,15 @@ object TestProcessHelper {
   // processes from running concurrently.
   val semaphore = new Semaphore(1)
 
-  private val scheduler = Executors.newScheduledThreadPool(1)
-  def schedule(seconds: Int)(f: => Unit): Unit =
-    scheduler.schedule({ () => f }: Runnable, seconds, TimeUnit.SECONDS)
-
-  /**
-    * Work around a CI problem where onExit() does not get called on
-    * [[seed.process.ProcessHandler]].
-    */
-  def scheduleTermination(process: ProcessHelper.Process): Unit =
-    TestProcessHelper.schedule(60) {
-      if (process.isRunning) {
-        Log.error(s"Process did not terminate after 60s")
-        Log.error("Forcing termination...")
-        process.kill()
-      }
-    }
-
   def runBloop(cwd: Path)(args: String*): Future[String] = {
     val sb = new StringBuilder
     val process = ProcessHelper.runBloop(cwd,
+      Log,
       { out =>
         Log.info(s"Process output: $out")
         sb.append(out + "\n")
       })(args: _*)
-    scheduleTermination(process)
 
-    process.termination.flatMap { statusCode =>
-      if (process.killed || statusCode == 0) Future.successful(sb.toString)
-      else Future.failed(new Exception("Status code: " + statusCode))
-    }
+    process.success.map(_ => sb.toString)
   }
 }

--- a/test/custom-command-target-fail/build.toml
+++ b/test/custom-command-target-fail/build.toml
@@ -1,0 +1,9 @@
+[project]
+scalaVersion = "2.13.0"
+
+[module.utils.target.gen-sources]
+command = "exit 1"
+
+[module.demo.jvm]
+moduleDeps = ["utils"]
+sources = ["demo"]

--- a/test/custom-command-target-fail/demo/Main.scala
+++ b/test/custom-command-target-fail/demo/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = println("hello")
+}


### PR DESCRIPTION
Currently, the build process continues when a command is not found
or exits with a non-zero code. This is undesired in CI setups as the
developers would not be aware of any problems related to custom
build targets.