### PR TITLE
Improve CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ This compiles the module to `build/` and runs it.
     * Default paths were chosen not to conflict in any way
 * Can be used in CIs like [Drone](https://drone.io/) using pre-built Docker image
 * UX
-    * Colour support
-    * Readable console output
+    * True colour output
     * User-friendly messages
+    * Unicode characters
 * Project creation wizard
 * Packaging support
     * Copy over dependencies
@@ -642,6 +642,21 @@ ivyPath = "/home/user/.ivy2/local"
 # Artefact cache path
 # Can be also set with --cache-path
 cachePath = "/home/user/.cache/coursier/v1"
+```
+
+The default values are indicated.
+
+### CLI settings
+In the `cli` section, you can find output-related configuration settings:
+
+```toml
+[cli]
+# Log level
+# Possible values: debug, detail, warn, info, error, silent
+level = "debug"
+
+# Use Unicode characters to indicate log levels
+unicode = true
 ```
 
 The default values are indicated.

--- a/src/main/scala/seed/Log.scala
+++ b/src/main/scala/seed/Log.scala
@@ -3,20 +3,76 @@ package seed
 import seed.cli.util.Ansi._
 import seed.cli.util.ColourScheme._
 
-class Log(f: String => Unit, map: String => String = identity) {
-  def prefix(text: String): Log = new Log(f, text + _)
+class Log(f: String => Unit,
+          map: String => String,
+          val level: LogLevel,
+          val unicode: Boolean
+         ) {
+  import Log._
+  import LogLevel._
 
-  def error(message: String): Unit =
-    f(foreground(red2)(bold("[error]") + " " + map(message)))
-
-  def warn(message: String): Unit =
-    f(foreground(yellow2)(bold("[warn]") + "  " + map(message)))
+  def prefix(text: String): Log = new Log(f, text + _, level, unicode)
 
   def debug(message: String): Unit =
-    f(foreground(green2)(bold("[debug]") + " " + map(message)))
+    if (level <= Debug)
+      f(foreground(green2)(
+        bold(if (unicode) "↪ " else "[debug] ") + map(message)))
+
+  def detail(message: String): Unit =
+    if (level <= Detail)
+      f((" " * (if (unicode) UnicodeLength else NonUnicodeLength)) +
+        foreground(blue3)(map(message)))
 
   def info(message: String): Unit =
-    f(foreground(blue2)(bold("[info]") + "  " + map(message)))
+    if (level <= Info)
+    f(foreground(blue2)(
+      bold(if (unicode) "ⓘ " else " [info] ") + map(message)))
+
+  def warn(message: String): Unit =
+    if (level <= Warn)
+      f(foreground(yellow2)(
+        bold(if (unicode) "⚠ " else " [warn] ") + map(message)))
+
+  def error(message: String): Unit =
+    if (level <= Error)
+      f(foreground(red2)(
+        bold(if (unicode) "✗ " else "[error] ") + map(message)))
+
+  def newLine(): Unit = f(" ")
 }
 
-object Log extends Log(println, identity)
+sealed abstract class LogLevel(val index: Int) extends Ordered[LogLevel] {
+  def compare(that: LogLevel): Int = index.compare(that.index)
+}
+
+object LogLevel {
+  case object Debug  extends LogLevel(0)
+  case object Detail extends LogLevel(1)
+  case object Info   extends LogLevel(2)
+  case object Warn   extends LogLevel(3)
+  case object Error  extends LogLevel(4)
+  case object Silent extends LogLevel(5)
+
+  val All = Map(
+    "debug" -> Debug,
+    "detail" -> Detail,
+    "info" -> Info,
+    "warn" -> Warn,
+    "error" -> Error,
+    "silent" -> Silent
+  )
+}
+
+object Log {
+  val UnicodeLength    = 2
+  val NonUnicodeLength = 8
+
+  def apply(seedConfig: seed.model.Config): Log =
+    new Log(println, identity, seedConfig.cli.level, seedConfig.cli.unicode)
+
+  /** For test cases, only use when errors should be silenced */
+  def silent: Log = new Log(println, identity, LogLevel.Silent, false)
+
+  /** For test cases, only report errors */
+  def urgent: Log = new Log(println, identity, LogLevel.Error, false)
+}

--- a/src/main/scala/seed/artefact/ArtefactResolution.scala
+++ b/src/main/scala/seed/artefact/ArtefactResolution.scala
@@ -248,6 +248,7 @@ object ArtefactResolution {
                  optionalArtefacts: Boolean,
                  platformDeps: Set[JavaDep],
                  compilerDeps: List[Set[JavaDep]],
+                 log: Log
                 ) = {
     val silent = packageConfig.silent || seedConfig.resolution.silent
 
@@ -255,21 +256,21 @@ object ArtefactResolution {
     val resolvedIvyPath = ivyPath.getOrElse(seedConfig.resolution.ivyPath)
     val resolvedCachePath = cachePath.getOrElse(seedConfig.resolution.cachePath)
 
-    Log.info("Configured resolvers:")
-    Log.info("  - " + resolvedIvyPath + " (Ivy)")
-    Log.info("  - " + resolvedCachePath + " (Coursier)")
-    build.resolvers.ivy.foreach(ivy => Log.info("  - " + Ansi.italic(ivy.url) + " (Ivy)"))
-    build.resolvers.maven.foreach(maven => Log.info("  - " + Ansi.italic(maven) + " (Maven)"))
+    log.info("Configured resolvers:")
+    log.detail("- " + Ansi.italic(resolvedIvyPath.toString) + " (Ivy)")
+    log.detail("- " + Ansi.italic(resolvedCachePath.toString) + " (Coursier)")
+    build.resolvers.ivy.foreach(ivy => log.detail("- " + Ansi.italic(ivy.url) + " (Ivy)"))
+    build.resolvers.maven.foreach(maven => log.detail("- " + Ansi.italic(maven) + " (Maven)"))
 
     def resolve(deps: Set[JavaDep]) =
       Coursier.resolveAndDownload(deps, build.resolvers, resolvedIvyPath,
-        resolvedCachePath, optionalArtefacts, silent)
+        resolvedCachePath, optionalArtefacts, silent, log)
 
-    Log.info("Resolving platform artefacts...")
+    log.info("Resolving platform artefacts...")
 
     val platformResolution = resolve(platformDeps)
 
-    Log.info("Resolving compiler artefacts...")
+    log.info("Resolving compiler artefacts...")
 
     // Resolve Scala compilers separately because Coursier merges dependencies
     // with different versions

--- a/src/main/scala/seed/artefact/MavenCentral.scala
+++ b/src/main/scala/seed/artefact/MavenCentral.scala
@@ -3,6 +3,7 @@ package seed.artefact
 import seed.model.Platform.{JVM, JavaScript, Native}
 import seed.model.{Artefact, Platform}
 import seed.Log
+import seed.cli.util.Ansi
 import seed.model.Build.VersionTag
 
 import scala.util.Try
@@ -18,18 +19,18 @@ object MavenCentral {
   def urlForArtefactMetaData(organisation: String, artefactName: String): String =
     urlForOrganisation(organisation) + s"$artefactName/maven-metadata.xml"
 
-  def requestHttp(url: String): String = {
-    Log.debug(s"Requesting $url...")
+  def requestHttp(url: String, log: Log): String = {
+    log.debug(s"Requesting ${Ansi.italic(url)}...")
     scalaj.http.Http(url).asString.body
   }
 
-  def isArtefactEligible(stable: Boolean)(version: String): Boolean =
+  def isArtefactEligible(stable: Boolean, log: Log)(version: String): Boolean =
     !stable || (stable && !SemanticVersioning.isPreRelease(version))
 
   /** @return If there no stable version was published for the artefact, return
    *          all unstable versions
    */
-  def parseVersionsXml(body: String, stable: Boolean): List[String] = {
+  def parseVersionsXml(body: String, stable: Boolean, log: Log): List[String] = {
     val versions = Try(pine.XmlParser.fromString(body))
       .toOption
       .toList
@@ -37,15 +38,15 @@ object MavenCentral {
         .byTagAll["version"]
         .flatMap(_.children.headOption)
         .collect { case pine.Text(t) => t }
-        .sorted(SemanticVersioning.versionOrdering))
+        .sorted(new SemanticVersioning(log).versionOrdering))
 
-    if (stable && versions.exists(isArtefactEligible(stable)))
-      versions.filter(isArtefactEligible(stable))
+    if (stable && versions.exists(isArtefactEligible(stable, log)))
+      versions.filter(isArtefactEligible(stable, log))
     else versions
   }
 
-  def fetchOrganisationArtefacts(organisation: String): List[String] = {
-    val response = requestHttp(urlForOrganisation(organisation))
+  def fetchOrganisationArtefacts(organisation: String, log: Log): List[String] = {
+    val response = requestHttp(urlForOrganisation(organisation), log)
     response.split("\n")
       .toList
       .filter(_.startsWith("<a href=\""))
@@ -56,10 +57,10 @@ object MavenCentral {
   /** @param stable Only consider stable artefacts (as opposed to pre-releases)
     * @return Found versions in ascending order
     */
-  def fetchLibraryArtefacts(artefact: Artefact, stable: Boolean): List[
+  def fetchLibraryArtefacts(artefact: Artefact, stable: Boolean, log: Log): List[
     (Platform, PlatformVersion, CompilerVersion)
   ] =
-    fetchOrganisationArtefacts(artefact.organisation)
+    fetchOrganisationArtefacts(artefact.organisation, log)
       .filter(_.startsWith(artefact.name))
       .map(_.drop(artefact.name.length + 1))
       .filter(a =>
@@ -67,9 +68,9 @@ object MavenCentral {
         a.startsWith("sjs") ||
         a.startsWith("native")
       ).map(parseArtefactName)
-       .filter(a => isArtefactEligible(stable)(a._2) &&
-                    isArtefactEligible(stable)(a._3))
-       .sortBy(_._2)(SemanticVersioning.versionOrdering)
+       .filter(a => isArtefactEligible(stable, log)(a._2) &&
+                    isArtefactEligible(stable, log)(a._3))
+       .sortBy(_._2)(new SemanticVersioning(log).versionOrdering)
 
   type PlatformVersion = String
   type CompilerVersion = String
@@ -89,15 +90,15 @@ object MavenCentral {
       (JVM, version, version)
   }
 
-  def fetchCompilerVersions(artefact: Artefact, stable: Boolean): List[String] = {
+  def fetchCompilerVersions(artefact: Artefact, stable: Boolean, log: Log): List[String] = {
     require(artefact.versionTag.isEmpty)
     val url = urlForArtefactMetaData(artefact.organisation, artefact.name)
-    parseVersionsXml(requestHttp(url), stable)
+    parseVersionsXml(requestHttp(url, log), stable, log)
   }
 
-  def fetchPlatformCompilerVersions(artefact: Artefact, stable: Boolean): List[String] = {
+  def fetchPlatformCompilerVersions(artefact: Artefact, stable: Boolean, log: Log): List[String] = {
     require(artefact.versionTag.contains(VersionTag.Full))
-    fetchLibraryArtefacts(artefact, stable).map(_._3).distinct
+    fetchLibraryArtefacts(artefact, stable, log).map(_._3).distinct
   }
 
   def trimCompilerVendor(version: String): String =
@@ -148,7 +149,8 @@ object MavenCentral {
                     platform: Platform,
                     platformVersion: PlatformVersion,
                     compilerVersion: CompilerVersion,
-                    stable: Boolean
+                    stable: Boolean,
+                    log: Log
                    ): List[String] = {
     val artefactName =
       artefact.versionTag.fold(artefact.name)(vt =>
@@ -156,6 +158,6 @@ object MavenCentral {
           compilerVersion))
     val url = urlForArtefactMetaData(artefact.organisation, artefactName)
 
-    parseVersionsXml(requestHttp(url), stable)
+    parseVersionsXml(requestHttp(url, log), stable, log)
   }
 }

--- a/src/main/scala/seed/artefact/SemanticVersioning.scala
+++ b/src/main/scala/seed/artefact/SemanticVersioning.scala
@@ -89,6 +89,10 @@ object SemanticVersioning {
   }
 
   private val comparator = new NaturalOrderComparator
+}
+
+class SemanticVersioning(log: Log) {
+  import SemanticVersioning._
 
   val versionOrdering = new Ordering[String] {
     override def compare(x: String, y: String): Int = {
@@ -103,7 +107,7 @@ object SemanticVersioning {
               v2.preReleaseVersion))
         case (v1, _) =>
           val version = if (v1.isEmpty) x else y
-          Log.error(s"Could not parse version '$version'. Falling back to comparison by natural ordering...")
+          log.error(s"Could not parse version '$version'. Falling back to comparison by natural ordering...")
 
           // Fall back to natural ordering comparison
           comparator.compare(x, y)

--- a/src/main/scala/seed/cli/BuildEvents.scala
+++ b/src/main/scala/seed/cli/BuildEvents.scala
@@ -1,24 +1,20 @@
 package seed.cli
 
 import java.net.URI
-import java.nio.file.Path
 
 import seed.Log
-import seed.cli.util.{Ansi, BloopCli, WsClient}
-import seed.config.BuildConfig
-import seed.model.Platform
-import seed.process.ProcessHelper
+import seed.cli.util.WsClient
 import seed.Cli.Command
 
 object BuildEvents {
-  def ui(command: Command.BuildEvents): Unit = {
+  def ui(command: Command.BuildEvents, log: Log): Unit = {
     val connection = command.webSocket
     val uri = s"ws://${connection.host}:${connection.port}"
-    Log.debug(s"Sending command to $uri...")
+    log.debug(s"Sending command to $uri...")
     val client = new WsClient(new URI(uri), () => {
       import io.circe.syntax._
       (WsCommand.BuildEvents: WsCommand).asJson.noSpaces
-    })
+    }, log)
     client.connect()
   }
 }

--- a/src/main/scala/seed/cli/BuildTarget.scala
+++ b/src/main/scala/seed/cli/BuildTarget.scala
@@ -3,6 +3,7 @@ package seed.cli
 import java.nio.file.Path
 
 import seed.Log
+import seed.cli.util.Ansi
 import seed.config.BuildConfig
 import seed.generation.util.PathUtil
 import seed.model
@@ -22,7 +23,7 @@ object BuildTarget {
                   ): List[Future[Unit]] = {
     def format(module: String, target: String): String = module + ":" + target
     def formatAll(targets: List[(String, String)]): String =
-      targets.map { case (m, t) => format(m, t) }.mkString(", ")
+      targets.map { case (m, t) => Ansi.italic(format(m, t)) }.mkString(", ")
 
     val targets = modules.flatMap {
       case util.Target.Parsed(m, Some(Right(t))) => List(m.name -> t.name)
@@ -50,7 +51,7 @@ object BuildTarget {
     log.info(s"Build path: $buildPath")
 
     allTargets.map { case (m, t) =>
-      val customLog = log.prefix(s"[${format(m, t)}]: ")
+      val customLog = log.prefix(Ansi.bold(s"[${format(m, t)}]: "))
 
       val modulePath = moduleProjectPaths(m)
       val target     = build.module(m).target(t)

--- a/src/main/scala/seed/cli/Generate.scala
+++ b/src/main/scala/seed/cli/Generate.scala
@@ -2,7 +2,7 @@ package seed.cli
 
 import java.nio.file.Path
 
-import seed.model
+import seed.{Log, model}
 import seed.Cli.Command
 import seed.generation.{Bloop, Idea}
 import seed.artefact.ArtefactResolution
@@ -11,7 +11,8 @@ object Generate {
   def ui(seedConfig: model.Config,
          projectPath: Path,
          build: model.Build,
-         command: Command.Generate
+         command: Command.Generate,
+         log: Log
         ): Unit = {
     val compilerDeps = ArtefactResolution.allCompilerDeps(build)
     val platformDeps = ArtefactResolution.allPlatformDeps(build)
@@ -26,12 +27,12 @@ object Generate {
     val (_, platformResolution, compilerResolution) =
       ArtefactResolution.resolution(seedConfig, build, command.packageConfig,
         optionalArtefacts = isIdea, platformDeps ++ libraryDeps,
-        compilerDeps)
+        compilerDeps, log)
 
     val tmpfs = command.packageConfig.tmpfs || seedConfig.build.tmpfs
     if (isBloop) Bloop.build(projectPath, build, platformResolution,
-      compilerResolution, tmpfs)
+      compilerResolution, tmpfs, log)
     if (isIdea) Idea.build(projectPath, projectPath, build, platformResolution,
-      compilerResolution, tmpfs)
+      compilerResolution, tmpfs, log)
   }
 }

--- a/src/main/scala/seed/cli/Link.scala
+++ b/src/main/scala/seed/cli/Link.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.nio.file.Path
 
 import seed.Log
-import seed.cli.util.WsClient
+import seed.cli.util.{Ansi, WsClient}
 import seed.config.BuildConfig
 import seed.model
 import seed.model.Config
@@ -12,37 +12,35 @@ import seed.Cli.Command
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Link {
-  def ui(buildPath: Path, seedConfig: Config, command: Command.Link): Unit = {
+  def ui(buildPath: Path, seedConfig: Config, command: Command.Link, log: Log): Unit =
     command.webSocket match {
       case Some(connection) =>
         if (command.watch)
-          Log.error("--watch cannot be combined with --connect")
+          log.error("--watch cannot be combined with --connect")
         else {
           val uri = s"ws://${connection.host}:${connection.port}"
-          Log.debug(s"Connecting to $uri...")
+          log.debug(s"Connecting to ${Ansi.italic(uri)}...")
           val client = new WsClient(new URI(uri), { () =>
             import io.circe.syntax._
             val build =
               if (buildPath.isAbsolute) buildPath else buildPath.toAbsolutePath
             (WsCommand.Link(build, command.modules): WsCommand).asJson.noSpaces
-          })
+          }, log)
           client.connect()
         }
 
       case None =>
         val tmpfs = command.packageConfig.tmpfs || seedConfig.build.tmpfs
-        link(buildPath, command.modules, command.watch, tmpfs, Log, _ => println) match {
+        link(buildPath, command.modules, command.watch, tmpfs, log, _ => println) match {
           case Left(errors) =>
-            errors.foreach(Log.error)
+            errors.foreach(log.error)
             sys.exit(1)
           case Right(future) => Await.result(future, Duration.Inf)
         }
     }
-  }
 
   def link(buildPath: Path,
            modules: List[String],

--- a/src/main/scala/seed/cli/util/Ansi.scala
+++ b/src/main/scala/seed/cli/util/Ansi.scala
@@ -30,6 +30,7 @@ object ColourScheme {
 
   val blue1 = Colour.parseHex("#5F819D")
   val blue2 = Colour.parseHex("#81A2BE")
+  val blue3 = Colour.parseHex("#92aec7")
 }
 
 object Ansi {
@@ -42,7 +43,7 @@ object Ansi {
   def background(colour: Colour)(text: String): String =
     escM("48", "2", colour.r.toString, colour.g.toString, colour.b.toString) + text + escM("49")
 
-  def bold      (text: String): String = escM("1") + text + escM("0")
-  def italic    (text: String): String = escM("3") + text + escM("0")
-  def underlined(text: String): String = escM("4") + text + escM("0")
+  def bold      (text: String): String = escM("1") + text + escM("22")
+  def italic    (text: String): String = escM("3") + text + escM("23")
+  def underlined(text: String): String = escM("4") + text + escM("24")
 }

--- a/src/main/scala/seed/cli/util/WsClient.scala
+++ b/src/main/scala/seed/cli/util/WsClient.scala
@@ -7,17 +7,17 @@ import org.java_websocket.client.WebSocketClient
 import org.java_websocket.handshake.ServerHandshake
 import seed.Log
 
-class WsClient(serverUri: URI, payload: () => String)
+class WsClient(serverUri: URI, payload: () => String, log: Log)
   extends WebSocketClient(serverUri)
 {
   override def onOpen(handshake: ServerHandshake): Unit = {
-    Log.debug("Connection established")
+    log.debug("Connection established")
     send(payload())
   }
   override def onClose(code: Int, reason: String, remote: Boolean): Unit =
-    Log.debug("Connection closed")
+    log.debug("Connection closed")
   override def onMessage(message: String): Unit = println(message)
   override def onMessage(message: ByteBuffer): Unit = {}
   override def onError(ex: Exception): Unit =
-    Log.error(s"An error occurred: $ex")
+    log.error(s"An error occurred: $ex")
 }

--- a/src/main/scala/seed/cli/util/WsServer.scala
+++ b/src/main/scala/seed/cli/util/WsServer.scala
@@ -14,27 +14,31 @@ import seed.cli.WsCommand
 
 class WsServer(address: InetSocketAddress,
                onDisconnect: WebSocket => Unit,
-               evalCommand: (WsServer, WebSocket, WsCommand) => Unit
+               evalCommand: (WsServer, WebSocket, WsCommand) => Unit,
+               log: Log
               ) extends WebSocketServer(address) {
   setReuseAddr(true)
 
   def clientIp(conn: WebSocket): String = conn.getRemoteSocketAddress.getAddress.getHostAddress
 
   override def onOpen(conn: WebSocket, handshake: ClientHandshake): Unit =
-    Log.debug("Client " + clientIp(conn) + " connected")
+    log.debug(s"Client ${Ansi.italic(clientIp(conn))} connected")
   override def onClose(conn: WebSocket, code: Int, reason: String, remote: Boolean): Unit = {
-    Log.debug("Client " + clientIp(conn) + " disconnected")
+    log.debug(s"Client ${Ansi.italic(clientIp(conn))} disconnected")
     onDisconnect(conn)
   }
   override def onError(conn: WebSocket, ex: Exception): Unit = ex.printStackTrace()
-  override def onStart(): Unit = setConnectionLostTimeout(100)
+  override def onStart(): Unit = {
+    setConnectionLostTimeout(100)
+    log.info(s"WebSocket server started on ${Ansi.italic(s"${address.getHostName}:${address.getPort}")}")
+  }
   override def onMessage(conn: WebSocket, message: String): Unit = try {
     decode[WsCommand](message) match {
       case Left(e) =>
-        Log.error("Could not process message from " + clientIp(conn) + ": " + e)
+        log.error(s"Could not process message from ${Ansi.italic(clientIp(conn))}: $e")
         conn.send(e.toString)
       case Right(c) =>
-        Log.debug("Message from " + clientIp(conn) + ": " + c)
+        log.debug(s"${Ansi.italic(c.description)} command received from ${Ansi.italic(clientIp(conn))}")
         evalCommand(this, conn, c)
     }
   } catch {

--- a/src/main/scala/seed/config/SeedConfig.scala
+++ b/src/main/scala/seed/config/SeedConfig.scala
@@ -19,8 +19,10 @@ object SeedConfig {
 
     implicit val pCodec = pathCodec(identity)
 
+    val log = Log(Config())
+
     def parse(path: Path) =
-      TomlUtils.parseFile(path, Toml.parseAs[Config](_), "Seed configuration", Log)
+      TomlUtils.parseFile(path, Toml.parseAs[Config](_), "Seed configuration", log)
         .getOrElse(sys.exit(1))
 
     userConfigPath match {
@@ -30,7 +32,7 @@ object SeedConfig {
       case Some(path) =>
         if (Files.exists(path)) parse(path)
         else {
-          Log.error(s"Invalid path to Seed configuration file provided: ${Ansi.italic(path.toString)}")
+          log.error(s"Invalid path to Seed configuration file provided: ${Ansi.italic(path.toString)}")
           sys.exit(1)
         }
     }

--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -164,7 +164,8 @@ object Idea {
                   compilerResolution: List[Coursier.ResolutionResult],
                   resolution: Coursier.ResolutionResult,
                   name: String,
-                  module: Module
+                  module: Module,
+                  log: Log
                  ): List[String] = {
     val isCrossBuild = module.targets.toSet.size > 1
 
@@ -172,10 +173,10 @@ object Idea {
       if (!module.js.exists(_.sources.nonEmpty)) List()
       else {
         val moduleName = if (!isCrossBuild) name else name + "-js"
-        Log.info(s"Creating JavaScript project ${Ansi.italic(moduleName)}...")
+        log.info(s"Creating JavaScript project ${Ansi.italic(moduleName)}...")
 
         if (module.js.get.root.isEmpty) {
-          Log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
+          log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
           List()
         } else {
           val scalaVersion = BuildConfig.scalaVersion(build.project,
@@ -223,10 +224,10 @@ object Idea {
       if (!module.jvm.exists(_.sources.nonEmpty)) List()
       else {
         val moduleName = if (!isCrossBuild) name else name + "-jvm"
-        Log.info(s"Creating JVM project ${Ansi.italic(moduleName)}...")
+        log.info(s"Creating JVM project ${Ansi.italic(moduleName)}...")
 
         if (module.jvm.get.root.isEmpty) {
-          Log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
+          log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
           List()
         } else {
           val scalaVersion = BuildConfig.scalaVersion(build.project,
@@ -272,10 +273,10 @@ object Idea {
       if (!module.native.exists(_.sources.nonEmpty)) List()
       else {
         val moduleName = if (!isCrossBuild) name else name + "-native"
-        Log.info(s"Creating native project ${Ansi.italic(moduleName)}...")
+        log.info(s"Creating native project ${Ansi.italic(moduleName)}...")
 
         if (module.native.get.root.isEmpty) {
-          Log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
+          log.error(s"Module ${Ansi.italic(moduleName)} does not specify root path, skipping...")
           List()
         } else {
           val scalaVersion = BuildConfig.scalaVersion(build.project,
@@ -321,10 +322,10 @@ object Idea {
     val shared =
       if (module.sources.isEmpty) List()
       else {
-        Log.info(s"Create shared project ${Ansi.italic(name)}...")
+        log.info(s"Create shared project ${Ansi.italic(name)}...")
 
         if (module.root.isEmpty) {
-          Log.error(s"Module ${Ansi.italic(name)} does not specify root path, skipping...")
+          log.error(s"Module ${Ansi.italic(name)} does not specify root path, skipping...")
           List()
         } else {
           val scalaVersion = BuildConfig.scalaVersion(build.project,
@@ -365,10 +366,10 @@ object Idea {
       }
 
     val customTargets = module.target.toList.flatMap { case (targetName, target) =>
-      Log.info(s"Create project for custom target ${Ansi.italic(name)}:$targetName...")
+      log.info(s"Create project for custom target ${Ansi.italic(name)}:$targetName...")
 
       if (target.root.isEmpty) {
-        Log.error(s"Module ${Ansi.italic(name)}:$targetName does not specify root path, skipping...")
+        log.error(s"Module ${Ansi.italic(name)}:$targetName does not specify root path, skipping...")
         List()
       } else {
         val scalaVersion = BuildConfig.scalaVersion(build.project, List(module))
@@ -413,11 +414,12 @@ object Idea {
             build: Build,
             resolution: Coursier.ResolutionResult,
             compilerResolution: List[Coursier.ResolutionResult],
-            tmpfs: Boolean): Unit = {
-    val buildPath = PathUtil.buildPath(projectPath, tmpfs)
+            tmpfs: Boolean,
+            log: Log): Unit = {
+    val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
     val ideaBuildPath = buildPath.resolve("idea")
 
-    Log.info(s"Build path: ${Ansi.italic(ideaBuildPath.toString)}")
+    log.info(s"Build path: ${Ansi.italic(ideaBuildPath.toString)}")
 
     val ideaPath      = outputPath.resolve(".idea")
     val modulesPath   = ideaPath.resolve("modules")
@@ -442,12 +444,12 @@ object Idea {
     val modules = build.module.toList.flatMap { case (name, module) =>
       buildModule(
         projectPath, ideaBuildPath, ideaPath, modulesPath, librariesPath, build,
-        compilerResolution, resolution, name, module)
+        compilerResolution, resolution, name, module, log)
     }
 
     createCompilerSettings(build, compilerResolution, ideaPath, modules)
     writeModules(projectPath, ideaPath, modulesPath, modules)
 
-    Log.info("IDEA project has been created")
+    log.info("IDEA project has been created")
   }
 }

--- a/src/main/scala/seed/generation/Package.scala
+++ b/src/main/scala/seed/generation/Package.scala
@@ -14,7 +14,8 @@ object Package {
   def create(source: List[(Path, String)],
              target: Path,
              mainClass: Option[String],
-             classPath: List[String]): Unit = {
+             classPath: List[String],
+             log: Log): Unit = {
     val manifest = new Manifest()
     val mainAttributes = manifest.getMainAttributes
     mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
@@ -25,10 +26,10 @@ object Package {
     val targetFile = new JarOutputStream(
       new FileOutputStream(target.toFile), manifest)
     source.foreach { case (path, jarPath) =>
-      Log.debug(s"Packaging ${Ansi.italic(path.toString)}...")
+      log.debug(s"Packaging ${Ansi.italic(path.toString)}...")
       add(path.toFile, jarPath, targetFile)
     }
-    Log.info(s"Written $target")
+    log.info(s"Written $target")
     targetFile.close()
   }
 

--- a/src/main/scala/seed/generation/util/PathUtil.scala
+++ b/src/main/scala/seed/generation/util/PathUtil.scala
@@ -6,15 +6,15 @@ import seed.Log
 import seed.cli.util.Ansi
 
 object PathUtil {
-  def tmpfsPath(projectPath: Path, log: Log = Log): Path = {
+  def tmpfsPath(projectPath: Path, log: Log): Path = {
     val name = projectPath.toAbsolutePath.getFileName.toString
     log.info("Build path set to tmpfs")
-    log.warn(s"Please ensure that there is no other project with the name ${Ansi.italic(name)} that also compiles to tmpfs")
+    log.warn(s"Please ensure that no other project with the name ${Ansi.italic(name)} compiles to tmpfs")
     Paths.get("/tmp").resolve("build-" + name)
   }
 
-  def buildPath(projectPath: Path, tmpfs: Boolean, log: Log = Log): Path =
-    if (tmpfs) tmpfsPath(projectPath) else projectPath.resolve("build")
+  def buildPath(projectPath: Path, tmpfs: Boolean, log: Log): Path =
+    if (tmpfs) tmpfsPath(projectPath, log) else projectPath.resolve("build")
 
   def normalisePath(pathVariable: String, root: Path)(path: Path): String = {
     val canonicalRoot = root.toFile.getCanonicalPath

--- a/src/main/scala/seed/model/Config.scala
+++ b/src/main/scala/seed/model/Config.scala
@@ -2,12 +2,15 @@ package seed.model
 
 import java.nio.file.Path
 
+import seed.LogLevel
 import seed.artefact.Coursier
 
-case class Config(build: Config.Build = Config.Build(),
+case class Config(cli: Config.Cli = Config.Cli(),
+                  build: Config.Build = Config.Build(),
                   resolution: Config.Resolution = Config.Resolution())
 
 object Config {
+  case class Cli(level: LogLevel = LogLevel.Debug, unicode: Boolean = true)
   case class Build(tmpfs: Boolean = false)
   case class Resolution(silent: Boolean = false,
                         ivyPath: Path = Coursier.DefaultIvyPath,

--- a/src/main/scala/seed/process/ProcessHelper.scala
+++ b/src/main/scala/seed/process/ProcessHelper.scala
@@ -71,7 +71,7 @@ object ProcessHelper {
                   onStdOut: String => Unit
                  ): Process = {
     log.info(s"Running command '${Ansi.italic(cmd.mkString(" "))}'...")
-    log.debug(s"    Working directory: ${Ansi.italic(cwd.toString)}")
+    log.detail(s"Working directory: ${Ansi.italic(cwd.toString)}")
 
     val termination = Promise[Unit]()
 
@@ -79,12 +79,12 @@ object ProcessHelper {
 
     modulePath.foreach { mp =>
       pb.environment().put("MODULE_PATH", mp)
-      log.debug(s"    Module path: ${Ansi.italic(mp)}")
+      log.detail(s"Module path: ${Ansi.italic(mp)}")
     }
 
     buildPath.foreach { bp =>
       pb.environment().put("BUILD_PATH", bp)
-      log.debug(s"    Build path: ${Ansi.italic(bp)}")
+      log.detail(s"Build path: ${Ansi.italic(bp)}")
     }
 
     pb.setProcessListener(new ProcessHandler(

--- a/src/test/scala/seed/LogSpec.scala
+++ b/src/test/scala/seed/LogSpec.scala
@@ -1,0 +1,34 @@
+package seed
+
+import minitest.SimpleTestSuite
+
+import scala.collection.mutable.ListBuffer
+
+object LogSpec extends SimpleTestSuite {
+  test("Check ordering of log levels") {
+    assert(LogLevel.Debug == LogLevel.Debug)
+    assert(LogLevel.Debug < LogLevel.Error)
+    assert(LogLevel.Error > LogLevel.Info)
+  }
+
+  test("Set log level to lowest") {
+    val result = ListBuffer[String]()
+    val log = new Log(result += _, identity, LogLevel.Debug, unicode = false)
+    log.debug("Hello World 1")
+    log.info("Hello World 2")
+    log.error("Hello World 3")
+    assertEquals(result.length, 3)
+    assert(result.exists(_.contains("Hello World 1")))
+    assert(result.exists(_.contains("Hello World 2")))
+    assert(result.exists(_.contains("Hello World 3")))
+  }
+
+  test("Set log level to highest") {
+    val result = ListBuffer[String]()
+    val log = new Log(result += _, identity, LogLevel.Error, unicode = false)
+    log.debug("Hello World 1")
+    log.info("Hello World 2")
+    log.error("Hello World 3")
+    assert(result.exists(_.contains("Hello World 3")))
+  }
+}

--- a/src/test/scala/seed/artefact/CoursierSpec.scala
+++ b/src/test/scala/seed/artefact/CoursierSpec.scala
@@ -1,6 +1,7 @@
 package seed.artefact
 
 import minitest.SimpleTestSuite
+import seed.Log
 import seed.model.Build
 import seed.model.Build.JavaDep
 
@@ -9,7 +10,8 @@ object CoursierSpec extends SimpleTestSuite {
     val dep = JavaDep("org.scala-js", "scalajs-dom_sjs0.6_2.12", "0.9.6")
     val resolution = Coursier.resolveAndDownload(Set(dep),
       Build.Resolvers(), Coursier.DefaultIvyPath,
-      Coursier.DefaultCachePath, optionalArtefacts = true, silent = true)
+      Coursier.DefaultCachePath, optionalArtefacts = true, silent = true,
+      Log.urgent)
 
     val result =
       Coursier.localArtefacts(resolution, Set(dep), optionalArtefacts = true)

--- a/src/test/scala/seed/artefact/SemanticVersioningSpec.scala
+++ b/src/test/scala/seed/artefact/SemanticVersioningSpec.scala
@@ -1,11 +1,15 @@
 package seed.artefact
 
 import minitest.SimpleTestSuite
+import seed.Log
 import seed.artefact.SemanticVersioning._
 
 import scala.util.Random
 
 object SemanticVersioningSpec extends SimpleTestSuite {
+  private val versionOrdering =
+    new SemanticVersioning(Log.urgent).versionOrdering
+
   test("Parse semantic versions") {
     assertEquals(parseVersion("1"), Some(Version(1)))
     assertEquals(parseVersion("1.0.0-beta"),

--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -27,7 +27,7 @@ object LinkSpec extends TestSuite[Unit] {
       BloopCli.parseStdOut(build)(output).foreach(events += _)
 
     val process = BloopCli.link(
-      build, projectPath, List("example-js"), watch = false, Log, onStdOut)
+      build, projectPath, List("example-js"), watch = false, Log.urgent, onStdOut)
 
     assert(process.isDefined)
 

--- a/src/test/scala/seed/config/BuildConfigSpec.scala
+++ b/src/test/scala/seed/config/BuildConfigSpec.scala
@@ -24,7 +24,7 @@ object BuildConfigSpec extends SimpleTestSuite {
       """.stripMargin, "UTF-8")
 
     val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
-      BuildConfig.load(Paths.get("/tmp/a.toml"), Log).get
+      BuildConfig.load(Paths.get("/tmp/a.toml"), Log.urgent).get
     assertEquals(projectPath, Paths.get("/tmp"))
     assertEquals(moduleProjectPaths, Map("example" -> Paths.get("/tmp")))
   }
@@ -40,7 +40,7 @@ object BuildConfigSpec extends SimpleTestSuite {
       """.stripMargin, "UTF-8")
 
     val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
-      BuildConfig.load(Paths.get("test/a.toml"), Log).get
+      BuildConfig.load(Paths.get("test/a.toml"), Log.urgent).get
     assertEquals(projectPath, Paths.get("test"))
     assertEquals(moduleProjectPaths, Map("example" -> Paths.get("test")))
   }
@@ -69,7 +69,7 @@ object BuildConfigSpec extends SimpleTestSuite {
       """.stripMargin, "UTF-8")
 
     val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
-      BuildConfig.load(Paths.get("/tmp/seed-root"), Log).get
+      BuildConfig.load(Paths.get("/tmp/seed-root"), Log.urgent).get
     assertEquals(moduleProjectPaths, Map(
       "root"  -> Paths.get("/tmp/seed-root"),
       "child" -> Paths.get("/tmp/seed-root/child")))

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -49,23 +49,25 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
   testAsync("Build project with compiler plug-in") { _ =>
     val BuildConfig.Result(build, projectPath, _) = BuildConfig.load(
-      Paths.get("test/example-paradise"), Log).get
+      Paths.get("test/example-paradise"), Log.urgent).get
     val buildPath = projectPath.resolve("build")
     if (Files.exists(buildPath)) FileUtils.deleteDirectory(buildPath.toFile)
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig))
+    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig),
+      Log.urgent)
     compileAndRun(projectPath)
   }
 
   testAsync("Build modules with different Scala versions") { _ =>
     val BuildConfig.Result(build, projectPath, _) = BuildConfig.load(
-      Paths.get("test/multiple-scala-versions"), Log).get
+      Paths.get("test/multiple-scala-versions"), Log.urgent).get
     val buildPath = projectPath.resolve("build")
     if (Files.exists(buildPath)) FileUtils.deleteDirectory(buildPath.toFile)
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig))
+    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig),
+      Log.urgent)
     TestProcessHelper.runBloop(projectPath)("run", "module211", "module212")
       .map { x =>
         val lines = x.split("\n").toList
@@ -78,22 +80,23 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     val path = Paths.get(s"test/$name")
 
     val BuildConfig.Result(build, projectPath, _) =
-      BuildConfig.load(path, Log).get
+      BuildConfig.load(path, Log.urgent).get
     val buildPath = projectPath.resolve("build")
     if (Files.exists(buildPath)) FileUtils.deleteDirectory(buildPath.toFile)
     val generatedFile = projectPath.resolve("demo").resolve("Generated.scala")
     if (Files.exists(generatedFile)) Files.delete(generatedFile)
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig))
+    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig),
+      Log.urgent)
 
     val result = seed.cli.Build.build(
       path,
       List("demo"),
       watch = false,
       tmpfs = false,
-      Log,
-      _ => println)
+      if (expectFailure) Log.silent else Log.urgent,
+      _ => _ => ())
 
     val future = result.right.get
 

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -53,10 +53,10 @@ object IdeaSpec extends SimpleTestSuite {
     val compilerDeps0 = ArtefactResolution.allCompilerDeps(build)
     val (_, platformResolution, compilerResolution) =
       ArtefactResolution.resolution(seed.model.Config(), build, packageConfig,
-        optionalArtefacts = false, Set(), compilerDeps0)
+        optionalArtefacts = false, Set(), compilerDeps0, Log.urgent)
 
     Idea.build(projectPath, outputPath, build, platformResolution,
-      compilerResolution, false)
+      compilerResolution, false, Log.silent)
 
     assertEquals(
       Files.exists(
@@ -71,10 +71,11 @@ object IdeaSpec extends SimpleTestSuite {
 
   test("Generate project with custom compiler options") {
     val BuildConfig.Result(build, projectPath, _) = BuildConfig.load(
-      Paths.get("test/compiler-options"), Log).get
+      Paths.get("test/compiler-options"), Log.urgent).get
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig))
+    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig),
+      Log.urgent)
 
     val ideaPath = projectPath.resolve(".idea")
 
@@ -93,10 +94,11 @@ object IdeaSpec extends SimpleTestSuite {
 
   test("Generate project with different Scala versions") {
     val BuildConfig.Result(build, projectPath, _) = BuildConfig.load(
-      Paths.get("test/multiple-scala-versions"), Log).get
+      Paths.get("test/multiple-scala-versions"), Log.urgent).get
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig))
+    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig),
+      Log.urgent)
 
     val ideaPath = projectPath.resolve(".idea")
 

--- a/src/test/scala/seed/generation/util/PathUtilSpec.scala
+++ b/src/test/scala/seed/generation/util/PathUtilSpec.scala
@@ -3,16 +3,17 @@ package seed.generation.util
 import java.nio.file.Paths
 
 import minitest.SimpleTestSuite
+import seed.Log
 
 object PathUtilSpec extends SimpleTestSuite {
   test("Default build paths") {
     val projectPath = Paths.get("test/compiler-options")
 
     assertEquals(
-      PathUtil.buildPath(projectPath, tmpfs = false),
+      PathUtil.buildPath(projectPath, tmpfs = false, Log.urgent),
       Paths.get("test/compiler-options/build"))
     assertEquals(
-      PathUtil.buildPath(projectPath, tmpfs = true),
+      PathUtil.buildPath(projectPath, tmpfs = true, Log.urgent),
       Paths.get("/tmp/build-compiler-options"))
   }
 }

--- a/src/test/scala/seed/generation/util/ProjectGeneration.scala
+++ b/src/test/scala/seed/generation/util/ProjectGeneration.scala
@@ -3,6 +3,7 @@ package seed.generation.util
 import java.nio.file.{Files, Path}
 
 import org.apache.commons.io.FileUtils
+import seed.Log
 import seed.artefact.{ArtefactResolution, Coursier}
 import seed.generation.Bloop
 import seed.model.Build.JavaDep
@@ -29,11 +30,11 @@ object ProjectGeneration {
     val resolution =
       Coursier.resolveAndDownload(platformDeps ++ libraryDeps, build.resolvers,
         resolvedIvyPath, resolvedCachePath, optionalArtefacts = false,
-        silent = true)
+        silent = true, Log.urgent)
     val compilerResolution =
       compilerDeps0.map(d =>
         Coursier.resolveAndDownload(d, build.resolvers, resolvedIvyPath,
-          resolvedCachePath, optionalArtefacts = false, silent = true))
+          resolvedCachePath, optionalArtefacts = false, silent = true, Log.urgent))
 
     build.module.foreach { case (id, module) =>
       Bloop.buildModule(
@@ -45,7 +46,8 @@ object ProjectGeneration {
         resolution,
         compilerResolution,
         id,
-        module)
+        module,
+        Log.urgent)
     }
   }
 

--- a/src/test/scala/seed/generation/util/TestProcessHelper.scala
+++ b/src/test/scala/seed/generation/util/TestProcessHelper.scala
@@ -18,13 +18,8 @@ object TestProcessHelper {
 
   def runBloop(cwd: Path)(args: String*): Future[String] = {
     val sb = new StringBuilder
-    val process = ProcessHelper.runBloop(cwd,
-      Log,
-      { out =>
-        Log.info(s"Process output: $out")
-        sb.append(out + "\n")
-      })(args: _*)
-
+    val process = ProcessHelper.runBloop(cwd, Log.urgent,
+      out => sb.append(out + "\n"))(args: _*)
     process.success.map(_ => sb.toString)
   }
 }


### PR DESCRIPTION
- Use Unicode symbols to indicate log level
- Introduce settings in configuration file to configure minimum log
  level and enable/disable Unicode symbols
- `Ansi`: Fix escape sequences to disable font effects
- `Log`: Set colour of entire line
- `ArtefactResolution`: Use consistent formatting for all resolvers
- `WsServer`: Improve log message of received commands
- `WsServer`: Only log message if server started successfully
- `PathUtil`: Shorten tmpfs warning
- Silence all log output in test cases

**Before:**
![old](https://user-images.githubusercontent.com/196819/61460918-652b0a80-a978-11e9-9ffc-e0b2e511639e.png)

**After:**
![new](https://user-images.githubusercontent.com/196819/61464210-90185d00-a97e-11e9-8b58-bff3c7eae395.png)
