### PR TITLE
Improve scaffold command

### DIFF
--- a/src/main/scala/seed/generation/util/PathUtil.scala
+++ b/src/main/scala/seed/generation/util/PathUtil.scala
@@ -1,6 +1,6 @@
 package seed.generation.util
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import seed.Log
 import seed.cli.util.Ansi
@@ -31,4 +31,8 @@ object PathUtil {
       pathVariable + "/" + relativePath + pathElems.drop(common.length).mkString("/")
     }
   }
+
+  def buildFilePath(userPath: Path): Path =
+    if (!Files.isDirectory(userPath)) userPath
+    else userPath.resolve("build.toml")
 }

--- a/src/test/scala/seed/cli/ScaffoldSpec.scala
+++ b/src/test/scala/seed/cli/ScaffoldSpec.scala
@@ -1,0 +1,30 @@
+package seed.cli
+
+import minitest.SimpleTestSuite
+import seed.Log
+import seed.model.{Organisation, Platform}
+import toml.Node.NamedTable
+import toml.Value.Str
+
+object ScaffoldSpec extends SimpleTestSuite {
+  test("Create build file one non-JVM platform") {
+    val scaffold = new Scaffold(Log.urgent, silent = true)
+    val result = scaffold.generateBuildFile(
+      "example",
+      stable = true,
+      organisation = Organisation.Lightbend,
+      platforms = Set(Platform.Native),
+      testFrameworks = Set()
+    )
+
+    val project = result.nodes(0).asInstanceOf[NamedTable]
+    assert(project.values("scalaVersion").asInstanceOf[Str].value.nonEmpty)
+    assert(project.values("scalaNativeVersion").asInstanceOf[Str].value.nonEmpty)
+    assert(!project.values.isDefinedAt("testFrameworks"))
+
+    val module = result.nodes(1).asInstanceOf[NamedTable]
+    assertEquals(module.ref, List("module", "example", "native"))
+
+    assertEquals(result.nodes.length, 2)
+  }
+}

--- a/src/test/scala/seed/generation/util/PathUtilSpec.scala
+++ b/src/test/scala/seed/generation/util/PathUtilSpec.scala
@@ -16,4 +16,16 @@ object PathUtilSpec extends SimpleTestSuite {
       PathUtil.buildPath(projectPath, tmpfs = true, Log.urgent),
       Paths.get("/tmp/build-compiler-options"))
   }
+
+  test("Build file path") {
+    assertEquals(
+      PathUtil.buildFilePath(Paths.get("/tmp")),
+      Paths.get("/tmp", "build.toml"))
+    assertEquals(
+      PathUtil.buildFilePath(Paths.get("/tmp", "build.toml")),
+      Paths.get("/tmp", "build.toml"))
+    assertEquals(
+      PathUtil.buildFilePath(Paths.get("/tmp", "test.toml")),
+      Paths.get("/tmp", "test.toml"))
+  }
 }


### PR DESCRIPTION
- Do not fail if a non-JVM platform was selected
- Drop all `scalaOptions`
  - `-Xfuture` has been deprecated in Scala 2.13
  - The other Scala options are not essential for a minimum working
    build file either and can be removed
- If no test frameworks were selected, do not set `testFrameworks`,
  add test modules or create any test folders
- Mark Typelevel Scala as legacy
- Improve formatting of questions
- Reduce output when user provided invalid input
- Test frameworks: Accept "none" as input since it is the indicated
  default value
- When there can be multiple options, allow spaces before/after the
  comma
- Fix crash when selecting Typelevel Scala, pre-releases and several
  test frameworks
- Fix bug which did not allow users to specify a custom file path:
  `seed init --build=test.toml`

If we go through the wizard using the default settings, we get the following result:

**Before:**
```toml
[project]
scalaVersion = "2.13.0"
scalaJsVersion = "0.6.28"
scalaOptions = [
  "-encoding",
  "UTF-8",
  "-unchecked",
  "-deprecation",
  "-Xfuture"
]
testFrameworks = []

[module.example]
root = "shared"
sources = ["shared/src"]
targets = [
  "jvm",
  "js"
]

[module.example.test]
sources = ["shared/test"]

[module.example.js]
root = "js"
sources = ["js/src"]

[module.example.test.js]
sources = ["js/test"]

[module.example.jvm]
root = "jvm"
sources = ["jvm/src"]

[module.example.test.jvm]
sources = ["jvm/test"]
```

**After:**
```toml
[project]
scalaVersion = "2.13.0"
scalaJsVersion = "0.6.28"

[module.example]
root = "shared"
sources = ["shared/src"]
targets = [
  "jvm",
  "js"
]

[module.example.js]
root = "js"
sources = ["js/src"]

[module.example.jvm]
root = "jvm"
sources = ["jvm/src"]
```