### PR TITLE
Package: Skip entries that were already added to the JAR file

### DIFF
--- a/src/main/scala/seed/Cli.scala
+++ b/src/main/scala/seed/Cli.scala
@@ -255,7 +255,7 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
           val BuildConfig.Result(build, projectPath, _) =
             BuildConfig.load(buildPath, log).getOrElse(sys.exit(1))
           cli.Package.ui(config, projectPath, build, module, output, libs,
-            packageConfig)
+            packageConfig, log)
         case Success(Config(configPath, buildPath, command: Command.Generate)) =>
           val config = SeedConfig.load(configPath)
           val log = Log(config)

--- a/src/main/scala/seed/config/util/TomlUtils.scala
+++ b/src/main/scala/seed/config/util/TomlUtils.scala
@@ -23,7 +23,7 @@ object TomlUtils {
         }
 
       case (value, _, _) =>
-        Left((List(), s"Log level expected, $value provided."))
+        Left((List(), s"Log level expected, $value provided"))
     }
 
     implicit val platformCodec: Codec[Platform] = Codec {

--- a/src/test/scala/seed/generation/PackageSpec.scala
+++ b/src/test/scala/seed/generation/PackageSpec.scala
@@ -1,0 +1,56 @@
+package seed.generation
+
+import java.nio.file.{Files, Paths}
+
+import minitest.TestSuite
+import org.apache.commons.io.FileUtils
+import seed.{Log, cli}
+import seed.Cli.{Command, PackageConfig}
+import seed.cli.util.Exit
+import seed.config.BuildConfig
+import seed.generation.util.TestProcessHelper
+import seed.generation.util.TestProcessHelper.ec
+import seed.model.Config
+
+object PackageSpec extends TestSuite[Unit] {
+  Exit.TestCases = true
+
+  override def setupSuite(): Unit = TestProcessHelper.semaphore.acquire()
+  override def tearDownSuite(): Unit = TestProcessHelper.semaphore.release()
+
+  override def setup(): Unit = ()
+  override def tearDown(env: Unit): Unit = ()
+
+  testAsync("Package modules with same package") { _ =>
+    val path = Paths.get("test/package-modules")
+
+    val BuildConfig.Result(build, projectPath, _) =
+      BuildConfig.load(path, Log.urgent).get
+    val buildPath = projectPath.resolve("build")
+    if (Files.exists(buildPath)) FileUtils.deleteDirectory(buildPath.toFile)
+    val packageConfig = PackageConfig(tmpfs = false, silent = false,
+      ivyPath = None, cachePath = None)
+    cli.Generate.ui(Config(), projectPath, build, Command.Bloop(packageConfig),
+      Log.urgent)
+
+    val result = seed.cli.Build.build(
+      path,
+      List("app"),
+      watch = false,
+      tmpfs = false,
+      Log.urgent,
+      _ => _ => ())
+
+    for {
+      _ <- result.right.get
+      result <- {
+        cli.Package.ui(Config(), projectPath, build, "app", None,
+          libs = true, packageConfig, Log.urgent)
+
+        util.TestProcessHelper.runCommand(
+          buildPath.resolve("dist"),
+          List("java", "-jar", "app.jar"))
+      }
+    } yield assertEquals(result.trim, "42")
+  }
+}

--- a/src/test/scala/seed/generation/util/TestProcessHelper.scala
+++ b/src/test/scala/seed/generation/util/TestProcessHelper.scala
@@ -22,4 +22,11 @@ object TestProcessHelper {
       out => sb.append(out + "\n"))(args: _*)
     process.success.map(_ => sb.toString)
   }
+
+  def runCommand(cwd: Path, cmd: List[String]): Future[String] = {
+    val sb = new StringBuilder
+    val process = ProcessHelper.runCommmand(cwd, cmd, None, None, Log.urgent,
+      out => sb.append(out + "\n"))
+    process.success.map(_ => sb.toString)
+  }
 }

--- a/test/package-modules/app/src/example/Main.scala
+++ b/test/package-modules/app/src/example/Main.scala
@@ -1,0 +1,5 @@
+package example
+
+object Main extends App {
+  println(Core.Value)
+}

--- a/test/package-modules/build.toml
+++ b/test/package-modules/build.toml
@@ -1,0 +1,10 @@
+[project]
+scalaVersion = "2.13.0"
+
+[module.core.jvm]
+sources = ["core/src"]
+
+[module.app.jvm]
+moduleDeps = ["core"]
+sources    = ["app/src"]
+mainClass  = "example.Main"

--- a/test/package-modules/core/src/example/Core.scala
+++ b/test/package-modules/core/src/example/Core.scala
@@ -1,0 +1,5 @@
+package example
+
+object Core {
+  val Value = 42
+}


### PR DESCRIPTION
Presently, an exception occurs if two modules share the same package
name. Change the behaviour in order not to add the same entry twice.
If the same compiled class file exists in multiple modules, issue a
warning. Also, break `Package` apart into smaller functions for
better readability.