### PR TITLE
Build all test projects in temporary folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.bloop/
-.idea/
-target/
 /.idea/
-/build/
-/test/meta-module/
+/.bloop/
+/.metals/
+/project/.bloop/
+
+target/

--- a/src/main/scala/seed/Cli.scala
+++ b/src/main/scala/seed/Cli.scala
@@ -261,7 +261,7 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
           val log = Log(config)
           val BuildConfig.Result(build, projectPath, _) =
             BuildConfig.load(buildPath, log).getOrElse(sys.exit(1))
-          cli.Generate.ui(config, projectPath, build, command, log)
+          cli.Generate.ui(config, projectPath, projectPath, build, command, log)
         case Success(Config(configPath, _, command: Command.Server)) =>
           val config = SeedConfig.load(configPath)
           val log = Log(config)

--- a/src/main/scala/seed/cli/Generate.scala
+++ b/src/main/scala/seed/cli/Generate.scala
@@ -10,6 +10,7 @@ import seed.artefact.ArtefactResolution
 object Generate {
   def ui(seedConfig: model.Config,
          projectPath: Path,
+         outputPath: Path,
          build: model.Build,
          command: Command.Generate,
          log: Log
@@ -30,9 +31,9 @@ object Generate {
         compilerDeps, log)
 
     val tmpfs = command.packageConfig.tmpfs || seedConfig.build.tmpfs
-    if (isBloop) Bloop.build(projectPath, build, platformResolution,
+    if (isBloop) Bloop.build(projectPath, outputPath, build, platformResolution,
       compilerResolution, tmpfs, log)
-    if (isIdea) Idea.build(projectPath, projectPath, build, platformResolution,
+    if (isIdea) Idea.build(projectPath, outputPath, build, platformResolution,
       compilerResolution, tmpfs, log)
   }
 }

--- a/src/main/scala/seed/cli/Server.scala
+++ b/src/main/scala/seed/cli/Server.scala
@@ -105,7 +105,7 @@ object Server {
       case WsCommand.BuildEvents => buildEventClients += wsClient
       case WsCommand.Build(buildPath, targets) =>
         seed.cli.Build.build(
-          buildPath, targets, watch = false, tmpfs, clientLog,
+          buildPath, None, targets, watch = false, tmpfs, clientLog,
           build => onStdOut(wsServer, wsClient, build, serverLog)
         ) match {
           case Left(errors) =>

--- a/src/main/scala/seed/generation/Bloop.scala
+++ b/src/main/scala/seed/generation/Bloop.scala
@@ -478,17 +478,19 @@ object Bloop {
   }
 
   def build(projectPath: Path,
+            outputPath: Path,
             build: Build,
             resolution: Coursier.ResolutionResult,
             compilerResolution: List[Coursier.ResolutionResult],
             tmpfs: Boolean,
             log: Log): Unit = {
-    val bloopPath = projectPath.resolve(".bloop")
+    val bloopPath = outputPath.resolve(".bloop")
     if (!Files.exists(bloopPath)) Files.createDirectory(bloopPath)
 
-    val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
-    val bloopBuildPath = buildPath.resolve("bloop")
+    val buildPath = PathUtil.buildPath(outputPath, tmpfs, log)
     log.info(s"Build path: ${Ansi.italic(buildPath.toString)}")
+
+    val bloopBuildPath = buildPath.resolve("bloop")
 
     import scala.collection.JavaConverters._
     Files.newDirectoryStream(bloopPath, "*.json").iterator().asScala

--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -416,7 +416,7 @@ object Idea {
             compilerResolution: List[Coursier.ResolutionResult],
             tmpfs: Boolean,
             log: Log): Unit = {
-    val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
+    val buildPath = PathUtil.buildPath(outputPath, tmpfs, log)
     val ideaBuildPath = buildPath.resolve("idea")
 
     log.info(s"Build path: ${Ansi.italic(ideaBuildPath.toString)}")

--- a/src/main/scala/seed/generation/util/PathUtil.scala
+++ b/src/main/scala/seed/generation/util/PathUtil.scala
@@ -17,14 +17,14 @@ object PathUtil {
     if (tmpfs) tmpfsPath(projectPath, log) else projectPath.resolve("build")
 
   def normalisePath(pathVariable: String, root: Path)(path: Path): String = {
-    val canonicalRoot = root.toFile.getCanonicalPath
-    val canonicalPath = path.toFile.getCanonicalPath
+    val absoluteRoot = root.toFile.getAbsolutePath
+    val absolutePath = path.toFile.getAbsolutePath
 
-    val rootElems = canonicalRoot.split("/").toList
-    val pathElems = canonicalPath.split("/").toList
+    val rootElems = absoluteRoot.split("/").toList
+    val pathElems = absolutePath.split("/").toList
     val common = pathElems.zip(rootElems).takeWhile { case (a, b) => a == b }
 
-    if (common.length == 1) canonicalPath
+    if (common.length == 1) absolutePath
     else {
       val levels = rootElems.length - common.length
       val relativePath = (0 until levels).map(_ => "../").mkString

--- a/src/test/scala/seed/build/LinkSpec.scala
+++ b/src/test/scala/seed/build/LinkSpec.scala
@@ -1,8 +1,7 @@
 package seed.build
 
-import java.nio.file.Paths
+import java.nio.file.Files
 
-import scala.concurrent.Future
 import scala.collection.mutable.ListBuffer
 import minitest.TestSuite
 import seed.Log
@@ -10,6 +9,7 @@ import seed.cli.util.BloopCli
 import seed.generation.util.{ProjectGeneration, TestProcessHelper}
 import seed.model.{BuildEvent, Platform}
 import seed.generation.util.TestProcessHelper.ec
+import seed.generation.util.BuildUtil.tempPath
 
 object LinkSpec extends TestSuite[Unit] {
   override def setupSuite(): Unit = TestProcessHelper.semaphore.acquire()
@@ -19,7 +19,9 @@ object LinkSpec extends TestSuite[Unit] {
   override def tearDown(env: Unit): Unit = ()
 
   testAsync("Link module and interpret Bloop events") { _ =>
-    val projectPath = Paths.get("test/module-link")
+    val projectPath = tempPath.resolve("module-link")
+    Files.createDirectory(projectPath)
+
     val build = ProjectGeneration.generateBloopCrossProject(projectPath)
 
     var events = ListBuffer[BuildEvent]()
@@ -39,7 +41,7 @@ object LinkSpec extends TestSuite[Unit] {
       require(events(1) == BuildEvent.Compiled("example", Platform.JavaScript))
       require(events(2).isInstanceOf[BuildEvent.Linked])
       require(events(2).asInstanceOf[BuildEvent.Linked]
-        .path.endsWith("test/module-link/build/example.js"))
+        .path.endsWith("module-link/build/example.js"))
     }
   }
 }

--- a/src/test/scala/seed/generation/BloopSpec.scala
+++ b/src/test/scala/seed/generation/BloopSpec.scala
@@ -1,10 +1,11 @@
 package seed.generation
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path}
 
 import bloop.config.ConfigEncoderDecoders
 import minitest.SimpleTestSuite
 import org.apache.commons.io.FileUtils
+import seed.generation.util.BuildUtil.tempPath
 
 object BloopSpec extends SimpleTestSuite {
   def parseBloopFile(path: Path): bloop.config.Config.File = {
@@ -13,7 +14,9 @@ object BloopSpec extends SimpleTestSuite {
   }
 
   test("Inherit javaDeps in child modules") {
-    val projectPath = Paths.get("test/inherit-javadeps")
+    val projectPath = tempPath.resolve("inherit-javadeps")
+    Files.createDirectory(projectPath)
+
     val bloopPath = projectPath.resolve(".bloop")
     util.ProjectGeneration.generateJavaDepBloopProject(projectPath)
 

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -13,6 +13,8 @@ import seed.model.Build.{Module, Project}
 import seed.model.Platform.JVM
 import seed.model.{Build, Config}
 
+import seed.generation.util.BuildUtil.tempPath
+
 object IdeaSpec extends SimpleTestSuite {
   test("Normalise paths") {
     assertEquals(
@@ -27,6 +29,15 @@ object IdeaSpec extends SimpleTestSuite {
     assertEquals(
       PathUtil.normalisePath(Idea.ModuleDir, Paths.get(".idea/modules"))(Paths.get("/tmp/build")),
       "/tmp/build")
+  }
+
+  test("Do not resolve symbolic links when normalising paths") {
+    Files.deleteIfExists(Paths.get("/tmp/tmp-link"))
+    Files.createSymbolicLink(Paths.get("/tmp/tmp-link"), Paths.get("/tmp"))
+
+    assertEquals(
+      PathUtil.normalisePath(Idea.ModuleDir, Paths.get(".idea/modules"))(Paths.get("/tmp/tmp-link")),
+      "/tmp/tmp-link")
   }
 
   test("Generate modules") {
@@ -74,10 +85,12 @@ object IdeaSpec extends SimpleTestSuite {
       Paths.get("test/compiler-options"), Log.urgent).get
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig),
-      Log.urgent)
+    val outputPath = tempPath.resolve("compiler-options")
+    Files.createDirectory(outputPath)
+    cli.Generate.ui(Config(), projectPath, outputPath, build,
+      Command.Idea(packageConfig), Log.urgent)
 
-    val ideaPath = projectPath.resolve(".idea")
+    val ideaPath = outputPath.resolve(".idea")
 
     val scalaCompiler =
       pine.XmlParser.fromString(FileUtils.readFileToString(
@@ -97,10 +110,12 @@ object IdeaSpec extends SimpleTestSuite {
       Paths.get("test/multiple-scala-versions"), Log.urgent).get
     val packageConfig = PackageConfig(tmpfs = false, silent = false,
       ivyPath = None, cachePath = None)
-    cli.Generate.ui(Config(), projectPath, build, Command.Idea(packageConfig),
-      Log.urgent)
+    val outputPath = tempPath.resolve("multiple-scala-versions-idea")
+    Files.createDirectory(outputPath)
+    cli.Generate.ui(Config(), projectPath, outputPath, build,
+      Command.Idea(packageConfig), Log.urgent)
 
-    val ideaPath = projectPath.resolve(".idea")
+    val ideaPath = outputPath.resolve(".idea")
 
     val scalaCompiler =
       pine.XmlParser.fromString(FileUtils.readFileToString(

--- a/src/test/scala/seed/generation/util/BuildUtil.scala
+++ b/src/test/scala/seed/generation/util/BuildUtil.scala
@@ -1,0 +1,7 @@
+package seed.generation.util
+
+import java.nio.file.Files
+
+object BuildUtil {
+  val tempPath = Files.createTempDirectory("seed")
+}

--- a/src/test/scala/seed/generation/util/ProjectGeneration.scala
+++ b/src/test/scala/seed/generation/util/ProjectGeneration.scala
@@ -11,8 +11,6 @@ import seed.model.{Build, Platform}
 
 object ProjectGeneration {
   def generate(projectPath: Path, build: Build): Unit = {
-    if (Files.exists(projectPath)) FileUtils.deleteDirectory(projectPath.toFile)
-
     val bloopPath = projectPath.resolve(".bloop")
     val buildPath = projectPath.resolve("build")
     val bloopBuildPath = buildPath.resolve("bloop")


### PR DESCRIPTION
- Use `createTempDirectory` instead of `/tmp` for better portability
- PathUtil: Use `normalisePath` as `getCanonicalPath` resolves
  symbolic links

The first change makes the test suite compatible with macOS.

Closes #30.