### PR TITLE
BuildTarget: Create build path if it does not exist

### DIFF
--- a/src/main/scala/seed/cli/BuildTarget.scala
+++ b/src/main/scala/seed/cli/BuildTarget.scala
@@ -1,6 +1,6 @@
 package seed.cli
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 import seed.Log
 import seed.cli.util.Ansi
@@ -47,7 +47,7 @@ object BuildTarget {
     val allTargets = (targets ++ inheritedTargets).distinct
 
     val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
-
+    if (!Files.exists(buildPath)) Files.createDirectories(buildPath)
     log.info(s"Build path: $buildPath")
 
     allTargets.map { case (m, t) =>

--- a/src/main/scala/seed/generation/Bloop.scala
+++ b/src/main/scala/seed/generation/Bloop.scala
@@ -484,13 +484,11 @@ object Bloop {
             tmpfs: Boolean,
             log: Log): Unit = {
     val bloopPath = projectPath.resolve(".bloop")
+    if (!Files.exists(bloopPath)) Files.createDirectory(bloopPath)
+
     val buildPath = PathUtil.buildPath(projectPath, tmpfs, log)
     val bloopBuildPath = buildPath.resolve("bloop")
-
     log.info(s"Build path: ${Ansi.italic(buildPath.toString)}")
-
-    if (!Files.exists(bloopPath)) Files.createDirectory(bloopPath)
-    if (!Files.exists(bloopBuildPath)) Files.createDirectories(bloopBuildPath)
 
     import scala.collection.JavaConverters._
     Files.newDirectoryStream(bloopPath, "*.json").iterator().asScala

--- a/test/custom-command-target/build.toml
+++ b/test/custom-command-target/build.toml
@@ -2,7 +2,9 @@
 scalaVersion = "2.13.0"
 
 [module.utils.target.gen-sources]
-command = "echo 'object Generated { val constant = 42 }' > demo/Generated.scala"
+# `ls $BUILD_PATH` checks whether the build path exists, otherwise it would
+# return with a non-zero code.
+command = "ls $BUILD_PATH && echo 'object Generated { val constant = 42 }' > demo/Generated.scala"
 await = true
 
 [module.demo.jvm]


### PR DESCRIPTION
If Seed is configured to compile to tmpfs and the operating system
is restarted, the build path disappears. Afterwards, commands such
as `cp -R <directory> $BUILD_PATH` will behave differently.

These changes will create the directory in `BuildTarget` prior to
the execution of any commands.