### PR TITLE
Bloop: Fix output path of submodules

### DIFF
--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -69,7 +69,10 @@ object Build {
                     moduleDeps: List[String] = List(),
                     mainClass: Option[String] = None,
                     targets: List[Platform] = List(),
-                    output: Option[Path] = None,
+
+                    // If this was a Path, it would include the directory
+                    // relative to the build file.
+                    output: Option[String] = None,
 
                     // JavaScript
                     jsdom: Boolean = false,

--- a/test/submodule-output-path/build.toml
+++ b/test/submodule-output-path/build.toml
@@ -1,0 +1,10 @@
+import = ["submodule"]
+
+[project]
+scalaVersion   = "2.13.0"
+scalaJsVersion = "0.6.28"
+
+[module.app.js]
+moduleDeps = ["base"]
+sources    = ["src"]
+output     = "js/app.js"

--- a/test/submodule-output-path/src/Main.scala
+++ b/test/submodule-output-path/src/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App { println("hello") }

--- a/test/submodule-output-path/submodule/build.toml
+++ b/test/submodule-output-path/submodule/build.toml
@@ -1,0 +1,10 @@
+[project]
+scalaVersion   = "2.13.0"
+scalaJsVersion = "0.6.28"
+
+[module.base.js]
+sources = ["src"]
+output  = "js/"
+
+[module.base2.js]
+sources = ["src"]

--- a/test/submodule-output-path/submodule/src/Main.scala
+++ b/test/submodule-output-path/submodule/src/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App { println("hello") }


### PR DESCRIPTION
Currently, the output path of a submodule includes the relative path
to its build file, although it should only be relative to the root
project's build path.

Another limitation that these changes address is that the output
folder was not created by Seed such that Bloop might fail to link
the project.