### PR TITLE
MavenCentral: Fix parsing of library artefacts

### DIFF
--- a/src/main/scala/seed/artefact/MavenCentral.scala
+++ b/src/main/scala/seed/artefact/MavenCentral.scala
@@ -54,15 +54,12 @@ object MavenCentral {
       .map(_.takeWhile(_ != '/'))
   }
 
-  /** @param stable Only consider stable artefacts (as opposed to pre-releases)
-    * @return Found versions in ascending order
-    */
-  def fetchLibraryArtefacts(artefact: Artefact, stable: Boolean, log: Log): List[
+  def parseLibraryArtefacts(artefacts: List[String], artefactName: String, stable: Boolean, log: Log): List[
     (Platform, PlatformVersion, CompilerVersion)
   ] =
-    fetchOrganisationArtefacts(artefact.organisation, log)
-      .filter(_.startsWith(artefact.name))
-      .map(_.drop(artefact.name.length + 1))
+    artefacts
+      .filter(_.startsWith(artefactName + "_"))
+      .map(_.drop(artefactName.length + 1))
       .filter(a =>
         a.headOption.exists(_.isDigit) ||
         a.startsWith("sjs") ||
@@ -71,6 +68,18 @@ object MavenCentral {
        .filter(a => isArtefactEligible(stable, log)(a._2) &&
                     isArtefactEligible(stable, log)(a._3))
        .sortBy(_._2)(new SemanticVersioning(log).versionOrdering)
+
+  /** @param stable Only consider stable artefacts (as opposed to pre-releases)
+    * @return Found versions in ascending order
+    */
+  def fetchLibraryArtefacts(artefact: Artefact, stable: Boolean, log: Log): List[
+    (Platform, PlatformVersion, CompilerVersion)
+  ] =
+    parseLibraryArtefacts(
+      fetchOrganisationArtefacts(artefact.organisation, log),
+      artefact.name,
+      stable,
+      log)
 
   type PlatformVersion = String
   type CompilerVersion = String

--- a/src/test/scala/seed/artefact/MavenCentralSpec.scala
+++ b/src/test/scala/seed/artefact/MavenCentralSpec.scala
@@ -1,0 +1,38 @@
+package seed.artefact
+
+import minitest.SimpleTestSuite
+import seed.model.Platform.JVM
+import seed.Log
+
+object MavenCentralSpec extends SimpleTestSuite {
+  test("Parse library artefact versions") {
+    val artefacts = List(
+      "scribe-slf4j18_2.11",
+      "scribe-slf4j18_2.12",
+      "scribe-slf4j18_2.13",
+
+      // Only these should match
+      "scribe-slf4j_2.11",
+      "scribe-slf4j_2.12",
+      "scribe-slf4j_2.13",
+      "scribe-slf4j_2.13.0-RC2")
+
+    def parse(stable: Boolean) =
+      MavenCentral.parseLibraryArtefacts(
+        artefacts,
+        "scribe-slf4j",
+        stable,
+        Log.urgent)
+
+    assertEquals(parse(stable = false), List(
+      (JVM, "2.11", "2.11"),
+      (JVM, "2.12", "2.12"),
+      (JVM, "2.13.0-RC2", "2.13.0-RC2"),
+      (JVM, "2.13", "2.13")))
+
+    assertEquals(parse(stable = true), List(
+      (JVM, "2.11", "2.11"),
+      (JVM, "2.12", "2.12"),
+      (JVM, "2.13", "2.13")))
+  }
+}


### PR DESCRIPTION
If an organisation contains multiple artefacts with the same prefix
followed by a digit, this digit would be considered as part of the
version:

```
✗ Could not parse version '8_2.12'. Falling back to comparison by natural ordering...
✗ Could not parse version '8_2.13'. Falling back to comparison by natural ordering...
✗ Could not parse version '8_2.13.0-RC2'. Falling back to comparison by natural ordering...
✗ Could not parse version '8_2.13.0-RC2'. Falling back to comparison by natural ordering...
[...]
```

These errors were reported to the user when running `seed update` on
projects that use the `scribe-slf4j` dependency.