### PR TITLE
Scaffold: Only return compatible compiler versions

### DIFF
--- a/src/test/scala/seed/cli/ScaffoldSpec.scala
+++ b/src/test/scala/seed/cli/ScaffoldSpec.scala
@@ -7,8 +7,9 @@ import toml.Node.NamedTable
 import toml.Value.Str
 
 object ScaffoldSpec extends SimpleTestSuite {
+  private val scaffold = new Scaffold(Log.urgent, silent = true)
+
   test("Create build file one non-JVM platform") {
-    val scaffold = new Scaffold(Log.urgent, silent = true)
     val result = scaffold.generateBuildFile(
       "example",
       stable = true,
@@ -26,5 +27,35 @@ object ScaffoldSpec extends SimpleTestSuite {
     assertEquals(module.ref, List("module", "example", "native"))
 
     assertEquals(result.nodes.length, 2)
+  }
+
+  test("Fetch compatible compiler versions for Typelevel Scala (stable)") {
+    val compilerVersions = scaffold.fetchCompilerVersions(
+      "org.typelevel", Set(Platform.JavaScript), stable = true)
+
+    assertEquals(compilerVersions,
+      Map(
+        Platform.JVM -> List("2.11.7", "2.11.8", "2.11.11-bin-typelevel-4",
+          "2.12.0", "2.12.1", "2.12.2-bin-typelevel-4",
+          "2.12.3-bin-typelevel-4", "2.12.4-bin-typelevel-4"),
+        Platform.JavaScript -> List(
+          "2.11.7", "2.11.8", "2.11.11", "2.12.0", "2.12.1", "2.12.2", "2.12.3",
+          "2.12.4")))
+  }
+
+  test("Fetch compatible compiler versions for Typelevel Scala (unstable)") {
+    val compilerVersions = scaffold.fetchCompilerVersions(
+      "org.typelevel", Set(Platform.JavaScript), stable = false)
+
+    assertEquals(compilerVersions,
+      Map(
+        Platform.JVM -> List("2.11.7", "2.11.8", "2.11.11-bin-typelevel-4",
+          "2.12.0-RC2", "2.12.0", "2.12.1", "2.12.2-bin-typelevel-4",
+          "2.12.3-bin-typelevel-4", "2.12.4-bin-typelevel-4",
+          "2.13.0-M2-bin-typelevel-4"
+        ),
+        Platform.JavaScript -> List(
+          "2.11.7", "2.11.8", "2.11.11", "2.12.0-RC2", "2.12.0", "2.12.1",
+          "2.12.2", "2.12.3", "2.12.4", "2.13.0-M2")))
   }
 }


### PR DESCRIPTION
If Typelevel Scala 2.12.4 is used along with Scala.js, the latest
compiler version could not be determined during `seed update`:

```
Platform compiler versions
╭────────────┬──────────────┬──────────┬────────────────────────╮
│ Platform   │ Organisation │ Compiler │ Version                │
├────────────┼──────────────┼──────────┼────────────────────────┤
│ JVM        │ Typelevel    │ Scala    │ 2.12.4-bin-typelevel-4 │
│ JavaScript │ Typelevel    │ Scala    │ Not available          │
│            │ Scala.js     │ Plug-in  │ Not available          │
╰────────────┴──────────────┴──────────┴────────────────────────╯
```

This is due to the fact that Scala.js supports Scala 2.13, and if
all libraries are compatible, `choosePlatformConfiguration()` would
choose 2.13 over 2.12. However, Typelevel Scala does not have a
stable 2.13 release which is why the columns above state "Not
available".

Change `fetchCompilerVersions()` such that for all non-JVM platforms
it filters out any Scala versions that are incompatible with the
ones offered by the organisation.