### PR TITLE
SemanticVersioning: Fix parsing of large pre-release versions

### DIFF
--- a/src/main/scala/seed/artefact/MavenCentral.scala
+++ b/src/main/scala/seed/artefact/MavenCentral.scala
@@ -43,7 +43,7 @@ object MavenCentral {
         _.byTagAll["version"]
           .flatMap(_.children.headOption)
           .collect { case pine.Text(t) => t }
-          .sorted(new SemanticVersioning(log).versionOrdering)
+          .sorted(new SemanticVersioning(log).stringVersionOrdering)
       )
 
     if (stable && versions.exists(isArtefactEligible(stable, log)))
@@ -87,7 +87,7 @@ object MavenCentral {
           isArtefactEligible(stable, log)(a._2) &&
             isArtefactEligible(stable, log)(a._3)
       )
-      .sortBy(_._2)(new SemanticVersioning(log).versionOrdering)
+      .sortBy(_._2)(new SemanticVersioning(log).stringVersionOrdering)
 
   /** @param stable Only consider stable artefacts (as opposed to pre-releases)
     * @return Found versions in ascending order

--- a/src/main/scala/seed/cli/Scaffold.scala
+++ b/src/main/scala/seed/cli/Scaffold.scala
@@ -149,7 +149,7 @@ class Scaffold(log: Log, silent: Boolean = false) {
           }
           .toList
           .distinct
-          .sortBy(_._1)(new SemanticVersioning(log).versionOrdering)
+          .sortBy(_._1)(new SemanticVersioning(log).stringVersionOrdering)
 
         val platformCompilerVersions =
           compilerVersions(platform).map(MavenCentral.trimCompilerVersion).toSet

--- a/src/main/scala/seed/cli/Update.scala
+++ b/src/main/scala/seed/cli/Update.scala
@@ -26,7 +26,7 @@ object Update {
         )
 
       case Some(newVersion) =>
-        val change = new SemanticVersioning(log).versionOrdering
+        val change = new SemanticVersioning(log).stringVersionOrdering
           .compare(oldVersion, newVersion)
         val versionChange = fansi.Str("(") ++ fansi.Bold.On(oldVersion) ++
           " → " ++ fansi.Bold.On(newVersion) ++ ")"


### PR DESCRIPTION
When updating projects with the JGit dependency, the following
exception is thrown:

```
Exception in thread "main" java.lang.NumberFormatException: For input string: "201202151440"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:583)
        at java.lang.Integer.parseInt(Integer.java:615)
        at scala.collection.immutable.StringLike.toInt(StringLike.scala:304)
        at scala.collection.immutable.StringLike.toInt$(StringLike.scala:304)
        at scala.collection.immutable.StringOps.toInt(StringOps.scala:33)
        at seed.artefact.SemanticVersioning$.parsePreReleaseParts(SemanticVersioning.scala:59)
        at seed.artefact.SemanticVersioning$.parseVersion(SemanticVersioning.scala:94)
```

Changes:
- Represent pre-release versions as longs to prevent this exception
- Create pre-release tag `Commit` for versions in Git notation
- Change ordering of `Snapshot` to reflect real-world usage