### PR TITLE
BuildConfig: Only include modules with same platform in classpath

### DIFF
--- a/src/main/scala/seed/config/BuildConfig.scala
+++ b/src/main/scala/seed/config/BuildConfig.scala
@@ -357,33 +357,51 @@ object BuildConfig {
     build: Build,
     module: Module
   ): List[Path] =
-    jsModuleDeps(module).flatMap(
-      name =>
-        buildPath.resolve(targetName(build, name, JavaScript)) +:
-          collectJsClassPath(buildPath, build, build.module(name))
-    )
+    jsModuleDeps(module)
+      .filter(name => hasTarget(build, name, Platform.JavaScript))
+      .flatMap(
+        name =>
+          buildPath
+            .resolve(targetName(build, name, JavaScript)) +: collectJsClassPath(
+            buildPath,
+            build,
+            build.module(name)
+          )
+      )
 
   def collectNativeClassPath(
     buildPath: Path,
     build: Build,
     module: Module
   ): List[Path] =
-    nativeModuleDeps(module).flatMap(
-      name =>
-        buildPath.resolve(targetName(build, name, Native)) +:
-          collectNativeClassPath(buildPath, build, build.module(name))
-    )
+    nativeModuleDeps(module)
+      .filter(name => hasTarget(build, name, Platform.Native))
+      .flatMap(
+        name =>
+          buildPath
+            .resolve(targetName(build, name, Native)) +: collectNativeClassPath(
+            buildPath,
+            build,
+            build.module(name)
+          )
+      )
 
   def collectJvmClassPath(
     buildPath: Path,
     build: Build,
     module: Module
   ): List[Path] =
-    jvmModuleDeps(module).flatMap(
-      name =>
-        buildPath.resolve(targetName(build, name, JVM)) +:
-          collectJvmClassPath(buildPath, build, build.module(name))
-    )
+    jvmModuleDeps(module)
+      .filter(name => hasTarget(build, name, Platform.JVM))
+      .flatMap(
+        name =>
+          buildPath
+            .resolve(targetName(build, name, JVM)) +: collectJvmClassPath(
+            buildPath,
+            build,
+            build.module(name)
+          )
+      )
 
   def collectJsDeps(build: Build, module: Module): List[ScalaDep] =
     module.scalaDeps ++ module.js.map(_.scalaDeps).getOrElse(List()) ++

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -313,6 +313,11 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
         .resolve("demo.json")
       val result = readBloopJson(path)
 
+      // Do not include the `utils` classpath since the module is only a custom
+      // build target and does not have a JVM target.
+      assert(!result.project.classpath.exists(_.toString.contains("/utils")))
+      assert(result.project.classpath.forall(Files.exists(_)))
+
       // Should not include "utils" dependency since it does not have any
       // Scala sources and no Bloop module.
       assertEquals(result.project.dependencies, List())


### PR DESCRIPTION
When run with `--verbose`, Bloop indicates that it detected changes
on the `custom-command-target` project:

```
[D] Classpath hash changed!
[...]
+  FileHash(file: /tmp/build-custom-command-target/bloop/utils, hash: -3319929)
 )
```

This directory does not exist since the custom build target does not
have any Scala sources. Filter out all dependent modules in the
classpath that do not target the same platform as the base module.