### PR TITLE
Inherit settings when loading build file

### DIFF
--- a/src/main/scala/seed/Cli.scala
+++ b/src/main/scala/seed/Cli.scala
@@ -270,12 +270,13 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
           import command._
           val config = SeedConfig.load(configPath)
           val log    = Log(config)
-          val BuildConfig.Result(build, projectPath, _) =
+          val result =
             BuildConfig.load(buildPath, log).getOrElse(sys.exit(1))
           cli.Package.ui(
             config,
-            projectPath,
-            build,
+            result.projectPath,
+            result.resolvers,
+            result.build,
             module,
             output,
             libs,
@@ -287,9 +288,17 @@ ${underlined("Usage:")} seed [--build=<path>] [--config=<path>] <command>
             ) =>
           val config = SeedConfig.load(configPath)
           val log    = Log(config)
-          val BuildConfig.Result(build, projectPath, _) =
+          val result =
             BuildConfig.load(buildPath, log).getOrElse(sys.exit(1))
-          cli.Generate.ui(config, projectPath, projectPath, build, command, log)
+          cli.Generate.ui(
+            config,
+            result.projectPath,
+            result.projectPath,
+            result.resolvers,
+            result.build,
+            command,
+            log
+          )
         case Success(Config(configPath, _, command: Command.Server)) =>
           val config = SeedConfig.load(configPath)
           val log    = Log(config)

--- a/src/main/scala/seed/Log.scala
+++ b/src/main/scala/seed/Log.scala
@@ -83,6 +83,9 @@ object Log {
   def apply(seedConfig: seed.model.Config): Log =
     new Log(println, identity, seedConfig.cli.level, seedConfig.cli.unicode)
 
+  /** For test cases, only use for debugging purposes */
+  def debug: Log = new Log(println, identity, LogLevel.Debug, false)
+
   /** For test cases, only use when errors should be silenced */
   def silent: Log = new Log(println, identity, LogLevel.Silent, false)
 

--- a/src/main/scala/seed/artefact/SemanticVersioning.scala
+++ b/src/main/scala/seed/artefact/SemanticVersioning.scala
@@ -104,6 +104,9 @@ object SemanticVersioning {
     }
   }
 
+  def majorMinorVersion(version: String): String =
+    version.reverse.dropWhile(_ != '.').tail.reverse
+
   private val comparator = new NaturalOrderComparator
 
   implicit val versionOrdering = new Ordering[Version] {

--- a/src/main/scala/seed/cli/Generate.scala
+++ b/src/main/scala/seed/cli/Generate.scala
@@ -6,13 +6,16 @@ import seed.{Log, model}
 import seed.Cli.Command
 import seed.generation.{Bloop, Idea}
 import seed.artefact.ArtefactResolution
+import seed.config.BuildConfig.Build
+import seed.model.Build.Resolvers
 
 object Generate {
   def ui(
     seedConfig: model.Config,
     projectPath: Path,
     outputPath: Path,
-    build: model.Build,
+    resolvers: Resolvers,
+    build: Build,
     command: Command.Generate,
     log: Log
   ): Unit = {
@@ -31,6 +34,7 @@ object Generate {
     val (_, platformResolution, compilerResolution) =
       ArtefactResolution.resolution(
         seedConfig,
+        resolvers,
         build,
         command.packageConfig,
         optionalArtefacts,

--- a/src/main/scala/seed/cli/Link.scala
+++ b/src/main/scala/seed/cli/Link.scala
@@ -9,6 +9,7 @@ import seed.config.BuildConfig
 import seed.model
 import seed.model.Config
 import seed.Cli.Command
+import seed.config.BuildConfig.Build
 import zio._
 
 object Link {
@@ -62,18 +63,19 @@ object Link {
     watch: Boolean,
     tmpfs: Boolean,
     log: Log,
-    onStdOut: model.Build => String => Unit
+    onStdOut: Build => String => Unit
   ): Either[List[String], UIO[Unit]] =
     BuildConfig.load(buildPath, log) match {
       case None => Left(List())
-      case Some(BuildConfig.Result(build, projectPath, moduleProjectPaths)) =>
-        val parsedModules = modules.map(util.Target.parseModuleString(build))
+      case Some(result) =>
+        import result.{build, projectPath}
+        val parsedModules =
+          modules.map(util.Target.parseModuleString(result.build))
         util.Validation.unpack(parsedModules).right.map { allModules =>
           val processes = BuildTarget.buildTargets(
             build,
             allModules,
             projectPath,
-            moduleProjectPaths,
             watch,
             tmpfs,
             log

--- a/src/main/scala/seed/cli/Server.scala
+++ b/src/main/scala/seed/cli/Server.scala
@@ -8,8 +8,8 @@ import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import org.java_websocket.WebSocket
 import seed.Log
 import seed.cli.util.{BloopCli, RTS, WsServer}
-import seed.model
 import seed.Cli.Command
+import seed.config.BuildConfig.Build
 import seed.model.Config
 
 import scala.collection.JavaConverters._
@@ -87,7 +87,7 @@ object Server {
   def onStdOut(
     wsServer: WsServer,
     wsClient: WebSocket,
-    build: model.Build,
+    build: Build,
     serverLog: Log
   )(message: String): Unit = {
     wsClient.send(message)

--- a/src/main/scala/seed/cli/util/BloopCli.scala
+++ b/src/main/scala/seed/cli/util/BloopCli.scala
@@ -3,10 +3,8 @@ package seed.cli.util
 import java.nio.file.Path
 
 import seed.Log
-import seed.model.Build
+import seed.config.BuildConfig.Build
 import seed.process.ProcessHelper
-
-import seed.model
 import seed.model.BuildEvent
 import seed.model.Platform.{JVM, JavaScript, Native}
 import seed.model.Platform
@@ -21,7 +19,7 @@ object BloopCli {
   def skipOutput(output: String): Boolean = output.contains("\u001b[H\u001b[2J")
 
   def parseBloopModule(
-    build: model.Build,
+    build: Build,
     bloopName: String
   ): (String, Platform) =
     if (bloopName.endsWith("-js"))
@@ -32,13 +30,13 @@ object BloopCli {
       (bloopName.dropRight("-native".length), Native)
     else {
       require(
-        build.module(bloopName).targets.length == 1,
+        build(bloopName).module.targets.length == 1,
         "Only one target expected"
       )
-      (bloopName, build.module(bloopName).targets.head)
+      (bloopName, build(bloopName).module.targets.head)
     }
 
-  def parseStdOut(build: model.Build)(message: String): Option[BuildEvent] = {
+  def parseStdOut(build: Build)(message: String): Option[BuildEvent] = {
     val parts = message.split(" ")
     if (parts(0) == "Compiling") {
       val (module, platform) = parseBloopModule(build, parts(1))

--- a/src/main/scala/seed/cli/util/Target.scala
+++ b/src/main/scala/seed/cli/util/Target.scala
@@ -1,5 +1,6 @@
 package seed.cli.util
 
+import seed.config.BuildConfig.Build
 import seed.model.Build.Module
 import seed.model.{Build, Platform}
 
@@ -17,11 +18,11 @@ object Target {
     else {
       def invalidName(name: String) =
         Left(s"Invalid module name: ${Ansi
-          .italic(name)}. Valid names: ${build.module.keys.mkString(", ")}")
+          .italic(name)}. Valid names: ${build.keys.mkString(", ")}")
 
       if (!module.contains(":")) {
-        if (!build.module.contains(module)) invalidName(module)
-        else Right(Parsed(ModuleRef(module, build.module(module)), None))
+        if (!build.contains(module)) invalidName(module)
+        else Right(Parsed(ModuleRef(module, build(module).module), None))
       } else {
         val parts = module.split(":")
         if (parts.length != 2) {
@@ -29,24 +30,20 @@ object Target {
         } else {
           val (name, target) = (parts(0), parts(1))
 
-          if (!build.module.contains(name)) invalidName(name)
+          if (!build.contains(name)) invalidName(name)
           else {
-            build
-              .module(name)
-              .targets
+            build(name).module.targets
               .find(_.id == target)
               .map(Left(_))
               .orElse(
-                build
-                  .module(name)
-                  .target
+                build(name).module.target
                   .get(target)
                   .map(tgt => Right(TargetRef(target, tgt)))
               ) match {
               case None =>
                 Left(s"Invalid build target ${Ansi.italic(target)} provided")
               case Some(tgt) =>
-                Right(Parsed(ModuleRef(name, build.module(name)), Some(tgt)))
+                Right(Parsed(ModuleRef(name, build(name).module), Some(tgt)))
             }
           }
         }

--- a/src/main/scala/seed/config/util/TomlUtils.scala
+++ b/src/main/scala/seed/config/util/TomlUtils.scala
@@ -6,7 +6,7 @@ import org.apache.commons.io.FileUtils
 import seed.{Log, LogLevel}
 import seed.cli.util.Ansi
 import seed.model.Build.{PlatformModule, VersionTag}
-import seed.model.{Build, Platform}
+import seed.model.{Platform, TomlBuild}
 import toml.{Codec, Value}
 
 import scala.util.Try
@@ -134,13 +134,13 @@ object TomlUtils {
 
   def parseBuildToml(
     projectPath: Path
-  )(content: String): Either[Codec.Error, Build] = {
+  )(content: String): Either[Codec.Error, TomlBuild] = {
     import toml._
     import toml.Codecs._
     import seed.config.util.TomlUtils.Codecs._
 
     implicit val pCodec = pathCodec(fixPath(projectPath, _))
 
-    Toml.parseAs[Build](content)
+    Toml.parseAs[TomlBuild](content)
   }
 }

--- a/src/main/scala/seed/generation/util/IdeaFile.scala
+++ b/src/main/scala/seed/generation/util/IdeaFile.scala
@@ -1,5 +1,6 @@
 package seed.generation.util
 
+import seed.artefact.SemanticVersioning
 import seed.generation.Bloop
 
 import pine._
@@ -95,7 +96,7 @@ object IdeaFile {
     val languageLevel =
       library.compilerInfo.map {
         case CompilerInfo(version, _) =>
-          val level = "Scala_" + Bloop
+          val level = "Scala_" + SemanticVersioning
             .majorMinorVersion(version)
             .replaceAllLiterally(".", "_")
           xml"""<language-level>$level</language-level>"""

--- a/src/main/scala/seed/generation/util/ScalaCompiler.scala
+++ b/src/main/scala/seed/generation/util/ScalaCompiler.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import seed.artefact.Coursier
 import seed.config.BuildConfig
 import seed.artefact.ArtefactResolution
+import seed.config.BuildConfig.Build
 import seed.model.Build.Module
 import seed.model.Platform.{JavaScript, Native}
 import seed.model.{Artefact, Build, Platform}
@@ -43,9 +44,9 @@ object ScalaCompiler {
   ): List[String] = {
     import ArtefactResolution.mergeDeps
 
-    val platformVer = BuildConfig.platformVersion(build, module, platform)
+    val platformVer = BuildConfig.platformVersion(module, platform)
     val moduleDeps  = BuildConfig.collectModuleDeps(build, module, platform)
-    val modules     = moduleDeps.map(build.module) :+ module
+    val modules     = moduleDeps.map(build(_).module) :+ module
     val artefacts =
       (if (platform == JavaScript) List(Artefact.ScalaJsCompiler -> platformVer)
        else if (platform == Native)

--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -4,9 +4,9 @@ import java.nio.file.Path
 
 import seed.artefact.MavenCentral
 
-case class Build(
+case class TomlBuild(
   `import`: List[Path] = List(),
-  project: Build.Project,
+  project: Build.Project = Build.Project(),
   resolvers: Build.Resolvers = Build.Resolvers(),
   module: Map[String, Build.Module]
 )
@@ -58,17 +58,35 @@ object Build {
   )
 
   case class Project(
-    scalaVersion: String,
+    scalaVersion: Option[String] = None,
     scalaJsVersion: Option[String] = None,
     scalaNativeVersion: Option[String] = None,
     scalaOptions: List[String] = List(),
-    scalaOrganisation: String = Organisation.Lightbend.packageName,
+    scalaOrganisation: Option[String] = None,
     testFrameworks: List[String] = List(),
     compilerDeps: List[ScalaDep] = List()
-  )
+  ) {
+    def toModule =
+      Module(
+        scalaVersion = scalaVersion,
+        scalaJsVersion = scalaJsVersion,
+        scalaNativeVersion = scalaNativeVersion,
+        scalaOptions = scalaOptions,
+        scalaOrganisation = scalaOrganisation,
+        testFrameworks = testFrameworks,
+        compilerDeps = compilerDeps
+      )
+  }
 
+  // TODO Instead of using this `case class` directly, create a polymorphic
+  //      version for different platform types
   case class Module(
     scalaVersion: Option[String] = None,
+    scalaJsVersion: Option[String] = None,
+    scalaNativeVersion: Option[String] = None,
+    scalaOptions: List[String] = List(),
+    scalaOrganisation: Option[String] = None,
+    testFrameworks: List[String] = List(),
     root: Option[Path] = None,
     sources: List[Path] = List(),
     resources: List[Path] = List(),
@@ -81,10 +99,10 @@ object Build {
     // If this was a Path, it would include the directory
     // relative to the build file.
     output: Option[String] = None,
-    // JavaScript
+    // --- JavaScript
     jsdom: Boolean = false,
     emitSourceMaps: Boolean = true,
-    // Native
+    // --- Native
     gc: Option[String] = None,
     targetTriple: Option[String] = None,
     clang: Option[Path] = None,
@@ -92,10 +110,11 @@ object Build {
     linkerOptions: Option[List[String]] = None,
     compilerOptions: Option[List[String]] = None,
     linkStubs: Boolean = false,
-    test: Option[Module] = None,
+    // ---
     js: Option[Module] = None,
     jvm: Option[Module] = None,
     native: Option[Module] = None,
+    test: Option[Module] = None,
     target: Map[String, Build.Target] = Map()
   )
 

--- a/src/test/scala/seed/cli/util/TargetSpec.scala
+++ b/src/test/scala/seed/cli/util/TargetSpec.scala
@@ -1,28 +1,27 @@
 package seed.cli.util
 
+import java.nio.file.Paths
+
 import minitest.SimpleTestSuite
+import seed.config.BuildConfig.ModuleConfig
 import seed.model.{Build, Platform}
 import seed.model.Build.Module
 
 object TargetSpec extends SimpleTestSuite {
   test("Parse module string") {
     assertEquals(
-      Target.parseModuleString(
-        Build(project = Build.Project(""), module = Map())
-      )(""),
+      Target.parseModuleString(Map())(""),
       Left("Module name cannot be empty")
     )
 
     assertEquals(
-      Target.parseModuleString(
-        Build(project = Build.Project(""), module = Map())
-      )("test"),
+      Target.parseModuleString(Map())("test"),
       Left(s"Invalid module name: ${Ansi.italic("test")}. Valid names: ")
     )
 
     assertEquals(
       Target.parseModuleString(
-        Build(project = Build.Project(""), module = Map("test" -> Module()))
+        Map("test" -> ModuleConfig(Module(), Paths.get(".")))
       )("test:jvm"),
       Left(s"Invalid build target ${Ansi.italic("jvm")} provided")
     )
@@ -30,9 +29,11 @@ object TargetSpec extends SimpleTestSuite {
     assertEquals(
       Target
         .parseModuleString(
-          Build(
-            project = Build.Project(""),
-            module = Map("test" -> Module(targets = List(Platform.JVM)))
+          Map(
+            "test" -> ModuleConfig(
+              Module(targets = List(Platform.JVM)),
+              Paths.get(".")
+            )
           )
         )("test:jvm")
         .isRight,
@@ -41,7 +42,7 @@ object TargetSpec extends SimpleTestSuite {
 
     assertEquals(
       Target.parseModuleString(
-        Build(project = Build.Project(""), module = Map("test" -> Module()))
+        Map("test" -> ModuleConfig(Module(), Paths.get(".")))
       )("test:custom"),
       Left(s"Invalid build target ${Ansi.italic("custom")} provided")
     )
@@ -49,10 +50,11 @@ object TargetSpec extends SimpleTestSuite {
     assertEquals(
       Target
         .parseModuleString(
-          Build(
-            project = Build.Project(""),
-            module =
-              Map("test" -> Module(target = Map("custom" -> Build.Target())))
+          Map(
+            "test" -> ModuleConfig(
+              Module(target = Map("custom" -> Build.Target())),
+              Paths.get(".")
+            )
           )
         )("test:custom")
         .isRight,

--- a/src/test/scala/seed/config/BuildConfigSpec.scala
+++ b/src/test/scala/seed/config/BuildConfigSpec.scala
@@ -3,19 +3,160 @@ package seed.config
 import java.io.File
 
 import minitest.SimpleTestSuite
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import org.apache.commons.io.FileUtils
-import seed.Log
+import seed.{Log, LogLevel}
 import seed.config.util.TomlUtils
 import seed.generation.util.BuildUtil
-import seed.model.Build
-import seed.model.Build.{Project, ScalaDep, VersionTag}
+import seed.model.Build.{JavaDep, Resolvers, ScalaDep, VersionTag}
 import seed.model.Platform.{JVM, JavaScript}
-
 import BuildUtil.tempPath
+import seed.cli.util.Ansi
+import seed.config.BuildConfig.{Build, Result}
+import seed.model.{Build, Organisation, Platform}
+
+import scala.collection.mutable.ListBuffer
 
 object BuildConfigSpec extends SimpleTestSuite {
+  test("Set default values and inherit settings") {
+    val original = Map(
+      "base" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        targets = List(Platform.JVM),
+        javaDeps = List(JavaDep("org.postgresql", "postgresql", "42.2.5"))
+      ),
+      "example" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        moduleDeps = List("base"),
+        targets = List(Platform.JVM)
+      )
+    )
+
+    val inherited = Map(
+      "base" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        scalaOrganisation = Some(Organisation.Lightbend.packageName),
+        targets = List(Platform.JVM),
+        javaDeps = List(JavaDep("org.postgresql", "postgresql", "42.2.5")),
+        jvm = Some(
+          Build.Module(
+            scalaVersion = Some("2.12.8"),
+            scalaOrganisation = Some(Organisation.Lightbend.packageName),
+            javaDeps = List(JavaDep("org.postgresql", "postgresql", "42.2.5"))
+          )
+        )
+      ),
+      "example" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        scalaOrganisation = Some(Organisation.Lightbend.packageName),
+        moduleDeps = List("base"),
+        targets = List(Platform.JVM),
+        jvm = Some(
+          Build.Module(
+            scalaVersion = Some("2.12.8"),
+            scalaOrganisation = Some(Organisation.Lightbend.packageName),
+            moduleDeps = List("base")
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      original.mapValues(BuildConfig.inheritSettings(Build.Module())),
+      inherited
+    )
+  }
+
+  test("Test module") {
+    val original = Map(
+      "example" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        targets = List(Platform.JVM),
+        jvm = Some(Build.Module(moduleDeps = List("base"))),
+        test = Some(Build.Module(jvm = Some(Build.Module())))
+      )
+    )
+
+    val inherited = Map(
+      "example" -> Build.Module(
+        scalaVersion = Some("2.12.8"),
+        scalaOrganisation = Some(Organisation.Lightbend.packageName),
+        targets = List(Platform.JVM),
+        jvm = Some(
+          Build.Module(
+            scalaVersion = Some("2.12.8"),
+            scalaOrganisation = Some(Organisation.Lightbend.packageName),
+            moduleDeps = List("base")
+          )
+        ),
+        test = Some(
+          Build.Module(
+            scalaVersion = Some("2.12.8"),
+            scalaOrganisation = Some(Organisation.Lightbend.packageName),
+            targets = List(Platform.JVM),
+            jvm = Some(
+              Build.Module(
+                scalaVersion = Some("2.12.8"),
+                scalaOrganisation = Some(Organisation.Lightbend.packageName),
+                moduleDeps = List("base")
+              )
+            )
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      original.mapValues(BuildConfig.inheritSettings(Build.Module())),
+      inherited
+    )
+  }
+
+  def parseBuild(toml: String, log: Log = Log.urgent, fail: Boolean = false)(
+    f: Path => String
+  ): Build = {
+    val parsed = TomlUtils.parseBuildToml(Paths.get("."))(toml)
+    val build = BuildConfig.processBuild(
+      parsed.right.get,
+      Paths.get("."), { path =>
+        val build = parseBuild(f(path))(f)
+        Some(Result(Paths.get("."), Resolvers(), build))
+      },
+      Log.urgent
+    )
+
+    val valid = build.forall {
+      case (name, module) =>
+        BuildConfig.checkModule(build, name, module.module, log)
+    }
+
+    assertEquals(valid, !fail)
+    build
+  }
+
+  test("Minimal native build") {
+    val fooToml = """
+      |[module.demo.native]
+      |scalaVersion       = "2.11.11"
+      |scalaNativeVersion = "0.3.7"
+      |sources            = ["src/"]
+    """.stripMargin
+
+    val build = parseBuild(fooToml)(_ => "")
+
+    assertEquals(build("demo").module.targets, List(Platform.Native))
+    assertEquals(build("demo").module.native.get.scalaVersion, Some("2.11.11"))
+    assertEquals(
+      build("demo").module.native.get.scalaNativeVersion,
+      Some("0.3.7")
+    )
+    assertEquals(
+      build("demo").module.native.get.sources,
+      List(Paths.get("src/"))
+    )
+  }
+
   test("Resolve absolute project path") {
     FileUtils.write(
       tempPath.resolve("a.toml").toFile,
@@ -29,10 +170,9 @@ object BuildConfigSpec extends SimpleTestSuite {
       "UTF-8"
     )
 
-    val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
-      BuildConfig.load(tempPath.resolve("a.toml"), Log.urgent).get
-    assertEquals(projectPath, tempPath)
-    assertEquals(moduleProjectPaths, Map("example" -> tempPath))
+    val config = BuildConfig.load(tempPath.resolve("a.toml"), Log.urgent).get
+    assertEquals(config.projectPath, tempPath)
+    assertEquals(config.build("example").path, tempPath)
   }
 
   test("Resolve relative project path") {
@@ -48,10 +188,9 @@ object BuildConfigSpec extends SimpleTestSuite {
       "UTF-8"
     )
 
-    val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
-      BuildConfig.load(Paths.get("test/a.toml"), Log.urgent).get
-    assertEquals(projectPath, Paths.get("test"))
-    assertEquals(moduleProjectPaths, Map("example" -> Paths.get("test")))
+    val config = BuildConfig.load(Paths.get("test/a.toml"), Log.urgent).get
+    assertEquals(config.projectPath, Paths.get("test"))
+    assertEquals(config.build("example").path, Paths.get("test"))
     Files.delete(Paths.get("test/a.toml"))
   }
 
@@ -88,10 +227,10 @@ object BuildConfigSpec extends SimpleTestSuite {
       "UTF-8"
     )
 
-    val BuildConfig.Result(_, projectPath, moduleProjectPaths) =
+    val config =
       BuildConfig.load(tempPath.resolve("seed-root"), Log.urgent).get
     assertEquals(
-      moduleProjectPaths,
+      config.build.mapValues(_.path),
       Map(
         "root"  -> tempPath.resolve("seed-root"),
         "child" -> tempPath.resolve("seed-root").resolve("child")
@@ -102,13 +241,11 @@ object BuildConfigSpec extends SimpleTestSuite {
   test("Set target platforms on test modules") {
     val toml = """
       |[project]
-      |scalaVersion      = "2.12.4-bin-typelevel-4"
-      |scalaJsVersion    = "0.6.26"
-      |scalaOrganisation = "org.typelevel"
-      |testFrameworks    = ["minitest.runner.Framework"]
+      |scalaVersion   = "2.12.8"
+      |scalaJsVersion = "0.6.26"
+      |testFrameworks = ["minitest.runner.Framework"]
       |
       |[module.example]
-      |root    = "shared"
       |sources = ["shared/src"]
       |targets = ["js", "jvm"]
       |
@@ -122,23 +259,48 @@ object BuildConfigSpec extends SimpleTestSuite {
       |sources = ["js/test"]
     """.stripMargin
 
-    val buildRaw = TomlUtils.parseBuildToml(Paths.get("."))(toml)
-    val (build, _) = BuildConfig.processBuild(
-      buildRaw.right.get,
-      Paths.get("."),
-      _ =>
-        Some(
-          (
-            Build(project = Project(scalaVersion = "2.12.8"), module = Map()),
-            Map()
-          )
-        )
-    )
-
+    val build = parseBuild(toml)(_ => "")
     assertEquals(
-      build.module("example").test.get.targets,
+      build("example").module.test.get.targets,
       List(JavaScript, JVM)
     )
+    assert(build("example").module.test.get.js.isDefined)
+    assert(build("example").module.test.get.jvm.isDefined)
+  }
+
+  test("Set target platforms on test modules (2)") {
+    val toml =
+      """
+        |[project]
+        |scalaVersion   = "2.13.0"
+        |scalaJsVersion = "0.6.28"
+        |testFrameworks = ["minitest.runner.Framework"]
+        |
+        |[module.example]
+        |sources = ["shared/src"]
+        |mainClass = "a.b"
+        |scalaDeps = [
+        |  ["org.scalameta", "interactive", "4.1.0", "full"]
+        |]
+        |
+        |[module.example.js]
+        |[module.example.jvm]
+        |
+        |[module.example.test]
+        |sources = ["shared/test/"]
+      """.stripMargin
+
+    val build = parseBuild(toml)(_ => "")
+    assertEquals(
+      build("example").module.test.get.targets,
+      List(JVM, JavaScript)
+    )
+    assert(build("example").module.test.get.js.isDefined)
+    assert(build("example").module.test.get.jvm.isDefined)
+    assert(build("example").module.test.get.mainClass.isEmpty)
+    assert(build("example").module.test.get.scalaDeps.isEmpty)
+    assert(build("example").module.test.get.js.get.mainClass.isEmpty)
+    assert(build("example").module.test.get.js.get.scalaDeps.isEmpty)
   }
 
   test("Parse TOML with full Scala dependency") {
@@ -153,39 +315,42 @@ object BuildConfigSpec extends SimpleTestSuite {
       |]
     """.stripMargin
 
-    val buildRaw = TomlUtils.parseBuildToml(Paths.get("."))(toml)
-    val (build, _) = BuildConfig.processBuild(
-      buildRaw.right.get,
-      Paths.get("."),
-      _ =>
-        Some(
-          Build(project = Project(scalaVersion = "2.12.8"), module = Map()),
-          Map()
-        )
-    )
-
+    val build = parseBuild(toml)(_ => "")
     assertEquals(
-      build.module("example").jvm.get.scalaDeps,
+      build("example").module.jvm.get.scalaDeps,
       List(ScalaDep("org.scalameta", "interactive", "4.1.0", VersionTag.Full))
     )
   }
 
-  test("Copy compilerDeps from project definitions to modules") {
+  test("Inherit compilerDeps from project definition and base modules") {
     val fooToml = """
       |import = ["bar"]
       |
       |[project]
       |scalaVersion = "2.12.8"
+      |scalaJsVersion = "0.6.26"
       |compilerDeps = [
       |  ["foo", "foo", "1.0", "full"]
       |]
       |
       |[module.foo]
-      |sources = ["foo-jvm/src"]
+      |sources = ["foo/src"]
+      |
       |[module.foo.js]
       |sources = ["foo-js/src"]
       |compilerDeps = [
       |  ["foo-js", "foo-js", "1.0", "full"]
+      |]
+      |
+      |[module.foo2]
+      |sources = ["foo2/src"]
+      |compilerDeps = [
+      |  ["foo", "foo", "2.0", "full"]
+      |]
+      |
+      |[module.foo2.js]
+      |compilerDeps = [
+      |  ["foo", "foo", "3.0", "full"]
       |]
     """.stripMargin
 
@@ -197,27 +362,22 @@ object BuildConfigSpec extends SimpleTestSuite {
       |]
       |
       |[module.bar]
+      |scalaJsVersion = "0.6.26"
+      |targets = ["js"]
       |sources = ["bar/src"]
     """.stripMargin
 
-    val buildRaw = TomlUtils.parseBuildToml(Paths.get("."))(fooToml)
-    val (build, _) = BuildConfig.processBuild(
-      buildRaw.right.get,
-      Paths.get("."),
-      _ =>
-        TomlUtils
-          .parseBuildToml(Paths.get("."))(barToml)
-          .toOption
-          .map(build => build -> Map.empty)
-    )
+    val build = parseBuild(fooToml) {
+      case p if p == Paths.get("bar") => barToml
+    }
 
     assertEquals(
-      build.module("foo").compilerDeps,
+      build("foo").module.compilerDeps,
       List(ScalaDep("foo", "foo", "1.0", VersionTag.Full))
     )
 
     assertEquals(
-      build.module("foo").js.get.compilerDeps,
+      build("foo").module.js.get.compilerDeps,
       List(
         ScalaDep("foo", "foo", "1.0", VersionTag.Full),
         ScalaDep("foo-js", "foo-js", "1.0", VersionTag.Full)
@@ -225,8 +385,88 @@ object BuildConfigSpec extends SimpleTestSuite {
     )
 
     assertEquals(
-      build.module("bar").compilerDeps,
+      build("foo2").module.compilerDeps,
+      List(ScalaDep("foo", "foo", "2.0", VersionTag.Full))
+    )
+
+    assertEquals(
+      build("foo2").module.js.get.compilerDeps,
+      List(ScalaDep("foo", "foo", "3.0", VersionTag.Full))
+    )
+
+    assertEquals(
+      build("bar").module.compilerDeps,
       List(ScalaDep("bar", "bar", "1.0", VersionTag.Full))
+    )
+
+    assertEquals(
+      build("bar").module.js.get.compilerDeps,
+      List(ScalaDep("bar", "bar", "1.0", VersionTag.Full))
+    )
+  }
+
+  test("Inheritance of settings") {
+    val fooToml = """
+      |[project]
+      |scalaVersion = "2.12.8"
+      |testFrameworks = ["a.b"]
+      |scalaOptions = ["-deprecation"]
+      |
+      |[module.foo]
+      |scalaVersion = "2.11.11"
+      |sources = ["foo/src"]
+      |
+      |[module.foo.js]
+      |scalaJsVersion = "0.6.26"
+      |sources = ["foo-js/src"]
+      |testFrameworks = ["c.d"]
+      |
+      |[module.bar]
+      |targets = ["jvm"]
+      |sources = ["foo/src"]
+      |scalaOptions = ["-language:existentials"]
+      |testFrameworks = ["a.b"]
+    """.stripMargin
+
+    val build = parseBuild(fooToml)(_ => "")
+
+    assertEquals(build("foo").module.targets, List(Platform.JavaScript))
+    assertEquals(build("foo").module.scalaVersion, Some("2.11.11"))
+    assertEquals(build("foo").module.testFrameworks, List("a.b"))
+    assertEquals(build("foo").module.scalaOptions, List("-deprecation"))
+
+    assertEquals(build("foo").module.js.get.scalaVersion, Some("2.11.11"))
+    assertEquals(build("foo").module.js.get.testFrameworks, List("a.b", "c.d"))
+    assertEquals(build("foo").module.js.get.scalaOptions, List("-deprecation"))
+
+    assertEquals(build("bar").module.scalaVersion, Some("2.12.8"))
+    assertEquals(
+      build("bar").module.scalaOptions,
+      List("-deprecation", "-language:existentials")
+    )
+  }
+
+  test("Scala version compatibility") {
+    val buildToml = """
+      |[module.foo.jvm]
+      |scalaVersion = "2.11.11"
+      |sources = ["foo/src"]
+      |
+      |[module.bar.jvm]
+      |moduleDeps = ["foo"]
+      |scalaVersion = "2.12.8"
+      |sources = ["bar/src"]
+    """.stripMargin
+
+    val messages = ListBuffer[String]()
+    val log      = new Log(messages += _, identity, LogLevel.Error, false)
+    parseBuild(buildToml, log, fail = true)(_ => "")
+    assert(
+      messages.exists(
+        _.contains(
+          s"Scala version of ${Ansi.italic("bar:jvm")} (2.12.8) is incompatible with ${Ansi.italic("foo:jvm")} (2.11.11)"
+        )
+      )
     )
   }
 }

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -58,8 +58,9 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
   testAsync(
     "Build project with compiler plug-in defined on cross-platform module"
   ) { _ =>
-    val BuildConfig.Result(build, projectPath, _) =
+    val config =
       BuildConfig.load(Paths.get("test/example-paradise"), Log.urgent).get
+    import config._
     val buildPath = tempPath.resolve("example-paradise")
     Files.createDirectory(buildPath)
     val packageConfig = PackageConfig(
@@ -72,6 +73,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       Config(),
       projectPath,
       buildPath,
+      resolvers,
       build,
       Command.Bloop(packageConfig),
       Log.urgent
@@ -81,9 +83,10 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
   testAsync("Build project with compiler plug-in defined on platform modules") {
     _ =>
-      val BuildConfig.Result(build, projectPath, _) = BuildConfig
+      val config = BuildConfig
         .load(Paths.get("test/example-paradise-platform"), Log.urgent)
         .get
+      import config._
       val buildPath = tempPath.resolve("example-paradise-platform")
       Files.createDirectory(buildPath)
       val packageConfig = PackageConfig(
@@ -96,6 +99,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
         Config(),
         projectPath,
         buildPath,
+        resolvers,
         build,
         Command.Bloop(packageConfig),
         Log.urgent
@@ -104,8 +108,9 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
   }
 
   testAsync("Link JavaScript modules with custom target path") { _ =>
-    val BuildConfig.Result(build, projectPath, _) =
+    val config =
       BuildConfig.load(Paths.get("test/submodule-output-path"), Log.urgent).get
+    import config._
     val buildPath = tempPath.resolve("submodule-output-path")
     Files.createDirectory(buildPath)
     val packageConfig = PackageConfig(
@@ -118,6 +123,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       Config(),
       projectPath,
       buildPath,
+      resolvers,
       build,
       Command.Bloop(packageConfig),
       Log.urgent
@@ -140,8 +146,8 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
   testAsync("Build project with overridden compiler plug-in version") { _ =>
     val projectPath = Paths.get("test/example-paradise-versions")
-    val BuildConfig.Result(build, _, _) =
-      BuildConfig.load(projectPath, Log.urgent).get
+    val result      = BuildConfig.load(projectPath, Log.urgent).get
+    import result._
     val buildPath = tempPath.resolve("example-paradise-versions")
     Files.createDirectory(buildPath)
     val packageConfig = PackageConfig(
@@ -154,6 +160,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       Config(),
       projectPath,
       buildPath,
+      resolvers,
       build,
       Command.Bloop(packageConfig),
       Log.urgent
@@ -221,9 +228,10 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
   }
 
   testAsync("Build modules with different Scala versions") { _ =>
-    val BuildConfig.Result(build, projectPath, _) = BuildConfig
+    val config = BuildConfig
       .load(Paths.get("test/multiple-scala-versions"), Log.urgent)
       .get
+    import config._
     val buildPath = tempPath.resolve("multiple-scala-versions-bloop")
     Files.createDirectory(buildPath)
     val packageConfig = PackageConfig(
@@ -236,6 +244,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       Config(),
       projectPath,
       buildPath,
+      resolvers,
       build,
       Command.Bloop(packageConfig),
       Log.urgent
@@ -255,8 +264,8 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
   ): Future[Unit] = {
     val path = Paths.get(s"test/$name")
 
-    val BuildConfig.Result(build, projectPath, _) =
-      BuildConfig.load(path, Log.urgent).get
+    val config = BuildConfig.load(path, Log.urgent).get
+    import config._
     val buildPath = tempPath.resolve(name)
     Files.createDirectory(buildPath)
     val generatedFile = projectPath.resolve("demo").resolve("Generated.scala")
@@ -270,6 +279,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       Config(),
       projectPath,
       buildPath,
+      resolvers,
       build,
       Command.Bloop(packageConfig),
       Log.urgent

--- a/src/test/scala/seed/generation/BloopSpec.scala
+++ b/src/test/scala/seed/generation/BloopSpec.scala
@@ -18,7 +18,9 @@ object BloopSpec extends SimpleTestSuite {
     Files.createDirectory(projectPath)
 
     val bloopPath = projectPath.resolve(".bloop")
-    util.ProjectGeneration.generateJavaDepBloopProject(projectPath)
+    val build     = util.ProjectGeneration.generateJavaDepBloopProject(projectPath)
+
+    assertEquals(build("example").module.jvm.get.moduleDeps, List("base"))
 
     val base = parseBloopFile(bloopPath.resolve("base.json"))
     assert(

--- a/src/test/scala/seed/generation/PackageSpec.scala
+++ b/src/test/scala/seed/generation/PackageSpec.scala
@@ -11,6 +11,7 @@ import seed.generation.util.TestProcessHelper
 import seed.generation.util.TestProcessHelper.ec
 import seed.model.Config
 import seed.generation.util.BuildUtil.tempPath
+import seed.model.Build.Resolvers
 
 object PackageSpec extends TestSuite[Unit] {
   override def setupSuite(): Unit    = TestProcessHelper.semaphore.acquire()
@@ -22,8 +23,7 @@ object PackageSpec extends TestSuite[Unit] {
   testAsync("Package modules with same package") { _ =>
     val path = Paths.get("test/package-modules")
 
-    val BuildConfig.Result(build, projectPath, _) =
-      BuildConfig.load(path, Log.urgent).get
+    val config     = BuildConfig.load(path, Log.urgent).get
     val outputPath = tempPath.resolve("package-modules")
     Files.createDirectory(outputPath)
     val buildPath = outputPath.resolve("build")
@@ -35,9 +35,10 @@ object PackageSpec extends TestSuite[Unit] {
     )
     cli.Generate.ui(
       Config(),
-      projectPath,
+      config.projectPath,
       outputPath,
-      build,
+      config.resolvers,
+      config.build,
       Command.Bloop(packageConfig),
       Log.urgent
     )
@@ -58,7 +59,8 @@ object PackageSpec extends TestSuite[Unit] {
         cli.Package.ui(
           Config(),
           outputPath,
-          build,
+          Resolvers(),
+          config.build,
           "app",
           Some(buildPath),
           libs = true,

--- a/test/scala-native-module/build.toml
+++ b/test/scala-native-module/build.toml
@@ -1,0 +1,5 @@
+[module.demo.native]
+root               = "."
+scalaVersion       = "2.11.11"
+scalaNativeVersion = "0.3.7"
+sources            = ["src/"]

--- a/test/test-module/build.toml
+++ b/test/test-module/build.toml
@@ -1,0 +1,18 @@
+[project]
+scalaVersion   = "2.12.8"
+scalaJsVersion = "0.6.28"
+testFrameworks = ["minitest.runner.Framework"]
+
+[module.base.jvm]
+root      = "base"
+sources   = ["base/src"]
+scalaDeps = [["com.lihaoyi", "sourcecode", "0.1.5"]]
+
+[module.example.jvm]
+root       = "example"
+sources    = ["example/src"]
+moduleDeps = ["base"]
+
+# Do not inherit scalaDeps from `base` in generated IDEA module
+[module.example.test.jvm]
+sources = ["example/test"]


### PR DESCRIPTION
Centralise the logic for inheriting settings from the project
section and base modules. The inheritance step is now performed when
loading the build file. As a consequence, many functions do not need
to take a reference to the project definition or parent modules
anymore. This greatly simplifies the code for generating Bloop/IDEA
configurations, and makes the logic less error-prone.

The build file's project section is now entirely optional and its
values can be set on modules instead. Now, Scala options can be
extended in platform modules, for example to set additional flags
required by the Scala.js compiler such as
`-P:scalajs:sjsDefinedByDefault`.

Furthermore, every module is compiled with the Scala version and the
options it was defined with. Therefore, it is not possible to depend
on modules anymore which have an incompatible Scala version. For
example, including a 2.12 module in a 2.13 module will trigger an
error.

Closes #18.