### PR TITLE
BuildConfig: Avoid duplicate class paths

### DIFF
--- a/src/main/scala/seed/config/BuildConfig.scala
+++ b/src/main/scala/seed/config/BuildConfig.scala
@@ -472,6 +472,7 @@ object BuildConfig {
             build(name).module
           )
       )
+      .distinct
 
   def collectNativeClassPath(
     buildPath: Path,
@@ -489,6 +490,7 @@ object BuildConfig {
             build(name).module
           )
       )
+      .distinct
 
   def collectJvmClassPath(
     buildPath: Path,
@@ -506,6 +508,7 @@ object BuildConfig {
               build(name).module
             )
       )
+      .distinct
 
   def collectJsDeps(
     build: Build,

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -49,6 +49,48 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     for { _ <- compile; _ <- run } yield ()
   }
 
+  private val packageConfig = PackageConfig(
+    tmpfs = false,
+    silent = false,
+    ivyPath = None,
+    cachePath = None
+  )
+
+  test(
+    "Generate project with duplicate transitive module dependencies"
+  ) { _ =>
+    val config =
+      BuildConfig
+        .load(Paths.get("test/duplicate-transitive-dep"), Log.urgent)
+        .get
+    import config._
+    val buildPath = tempPath.resolve("duplicate-transitive-dep")
+    Files.createDirectory(buildPath)
+    cli.Generate.ui(
+      Config(),
+      projectPath,
+      buildPath,
+      resolvers,
+      build,
+      Command.Bloop(packageConfig),
+      Log.urgent
+    )
+
+    val bloopBuildPath = buildPath.resolve("build").resolve("bloop")
+
+    val bloopPath = buildPath.resolve(".bloop")
+    val root      = readBloopJson(bloopPath.resolve("root.json"))
+    val paths     = root.project.classpath.filter(_.startsWith(buildPath))
+    assertEquals(
+      paths,
+      List(
+        bloopBuildPath.resolve("a"),
+        bloopBuildPath.resolve("b"),
+        bloopBuildPath.resolve("shared")
+      )
+    )
+  }
+
   testAsync("Generate and compile meta modules") { _ =>
     val projectPath = tempPath.resolve("meta-module")
     util.ProjectGeneration.generateBloopCrossProject(projectPath)
@@ -63,12 +105,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     import config._
     val buildPath = tempPath.resolve("example-paradise")
     Files.createDirectory(buildPath)
-    val packageConfig = PackageConfig(
-      tmpfs = false,
-      silent = false,
-      ivyPath = None,
-      cachePath = None
-    )
     cli.Generate.ui(
       Config(),
       projectPath,
@@ -89,12 +125,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       import config._
       val buildPath = tempPath.resolve("example-paradise-platform")
       Files.createDirectory(buildPath)
-      val packageConfig = PackageConfig(
-        tmpfs = false,
-        silent = false,
-        ivyPath = None,
-        cachePath = None
-      )
       cli.Generate.ui(
         Config(),
         projectPath,
@@ -113,12 +143,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     import config._
     val buildPath = tempPath.resolve("submodule-output-path")
     Files.createDirectory(buildPath)
-    val packageConfig = PackageConfig(
-      tmpfs = false,
-      silent = false,
-      ivyPath = None,
-      cachePath = None
-    )
     cli.Generate.ui(
       Config(),
       projectPath,
@@ -150,12 +174,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     import result._
     val buildPath = tempPath.resolve("example-paradise-versions")
     Files.createDirectory(buildPath)
-    val packageConfig = PackageConfig(
-      tmpfs = false,
-      silent = false,
-      ivyPath = None,
-      cachePath = None
-    )
     cli.Generate.ui(
       Config(),
       projectPath,
@@ -234,12 +252,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     import config._
     val buildPath = tempPath.resolve("multiple-scala-versions-bloop")
     Files.createDirectory(buildPath)
-    val packageConfig = PackageConfig(
-      tmpfs = false,
-      silent = false,
-      ivyPath = None,
-      cachePath = None
-    )
     cli.Generate.ui(
       Config(),
       projectPath,
@@ -269,12 +281,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     val buildPath = tempPath.resolve(name)
     Files.createDirectory(buildPath)
     val generatedFile = projectPath.resolve("demo").resolve("Generated.scala")
-    val packageConfig = PackageConfig(
-      tmpfs = false,
-      silent = false,
-      ivyPath = None,
-      cachePath = None
-    )
     cli.Generate.ui(
       Config(),
       projectPath,

--- a/test/duplicate-transitive-dep/build.toml
+++ b/test/duplicate-transitive-dep/build.toml
@@ -1,0 +1,21 @@
+[project]
+scalaVersion = "2.12.8"
+
+[module.shared]
+sources = ["shared/"]
+targets = ["jvm"]
+
+[module.a]
+sources = ["a/"]
+targets = ["jvm"]
+moduleDeps = ["shared"]
+
+[module.b]
+sources = ["b/"]
+targets = ["jvm"]
+moduleDeps = ["shared"]
+
+[module.root]
+sources = ["root/"]
+targets = ["jvm"]
+moduleDeps = ["a", "b"]


### PR DESCRIPTION
This fixes a crash when generating a Bloop project with transitively
duplicate module dependencies.

Closes #47.