### PR TITLE
IDEA: Set correct module dependencies

### DIFF
--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -288,7 +288,7 @@ object Idea {
               ),
             moduleDeps =
               (if (!isCrossBuild) List() else List(name)) ++
-                collectJsModuleDeps(build, module).flatMap(
+                collectJsModuleDeps(build, jsModule).flatMap(
                   name => BuildConfig.targetNames(build, name, JavaScript)
                 ),
             projectPath = projectPath,
@@ -363,7 +363,7 @@ object Idea {
               ),
             moduleDeps =
               (if (!isCrossBuild) List() else List(name)) ++
-                collectJvmModuleDeps(build, module)
+                collectJvmModuleDeps(build, jvmModule)
                   .flatMap(name => BuildConfig.targetNames(build, name, JVM)),
             projectPath = projectPath,
             buildPath = buildPath,
@@ -436,7 +436,7 @@ object Idea {
               ),
             moduleDeps =
               (if (!isCrossBuild) List() else List(name)) ++
-                collectNativeModuleDeps(build, module).flatMap(
+                collectNativeModuleDeps(build, nativeModule).flatMap(
                   name => BuildConfig.targetNames(build, name, Native)
                 ),
             projectPath = projectPath,

--- a/test/platform-module-deps/build.toml
+++ b/test/platform-module-deps/build.toml
@@ -1,0 +1,11 @@
+[project]
+scalaVersion = "2.12.8"
+
+[module.core.jvm]
+root    = "jvm"
+sources = ["jvm/src/"]
+
+[module.example.jvm]
+moduleDeps = ["core"]
+root       = "example"
+sources    = ["example/src/"]


### PR DESCRIPTION
Currently, only module dependencies of cross-platform modules are
set when generating an IDEA project. Also include the module
dependencies of platform-specific modules.

This fixes a regression introduced in 51a27f5.