### PR TITLE
IDEA: Fix generation of projects with mixed Scala options

### DIFF
--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -183,7 +183,7 @@ object Idea {
       val target         = if (module.jvm.isDefined) JVM else module.targets.head
       val platformModule = BuildConfig.platformModule(module, target).get
 
-      m -> (module.scalaOptions ++ util.ScalaCompiler.compilerPlugIns(
+      m -> (platformModule.scalaOptions ++ util.ScalaCompiler.compilerPlugIns(
         build,
         platformModule,
         compilerResolution,

--- a/src/main/scala/seed/generation/util/IdeaFile.scala
+++ b/src/main/scala/seed/generation/util/IdeaFile.scala
@@ -134,7 +134,7 @@ object IdeaFile {
   def createScalaCompiler(
     compilerSettings: List[(Options, Modules)]
   ): String = {
-    def component(
+    def profile(
       options: List[String],
       modules: List[String]
     ): pine.Tag[Singleton] = {
@@ -142,21 +142,21 @@ object IdeaFile {
       val modulesAttr = modules.mkString(",")
       val parameters  = options.map(option => xml"<parameter value=$option />")
       xml"""
-        <component name="ScalaCompilerConfiguration">
-          <option name="incrementalityType" value="IDEA" />
-          <profile name=$profileName modules=$modulesAttr>
-            <parameters>$parameters</parameters>
-          </profile>
-        </component>
+        <profile name=$profileName modules=$modulesAttr>
+          <parameters>$parameters</parameters>
+        </profile>
       """
     }
 
-    val components = compilerSettings.map { case (a, b) => component(a, b) }
+    val profiles = compilerSettings.map { case (a, b) => profile(a, b) }
 
     xml"""
       <?xml version="1.0" encoding="UTF-8"?>
       <project version="4">
-        $components
+        <component name="ScalaCompilerConfiguration">
+          <option name="incrementalityType" value="IDEA" />
+          $profiles
+        </component>
       </project>
     """.toXml
   }

--- a/test/module-scala-options/build.toml
+++ b/test/module-scala-options/build.toml
@@ -1,0 +1,11 @@
+[module.core.jvm]
+scalaVersion      = "2.12.4-bin-typelevel-4"
+scalaOrganisation = "org.typelevel"
+scalaOptions      = ["-Yliteral-types"]
+root              = "core"
+sources           = ["core/src/"]
+
+[module.example.jvm]
+scalaVersion = "2.12.8"
+root         = "example"
+sources      = ["example/src/"]


### PR DESCRIPTION
Similarly to #52, the generation of compiler profiles for IDEA only
honoured Scala options of cross-platform modules. Take the Scala
options of platform modules instead.

Furthermore, `IdeaFile` used the wrong format to encode compiler
profiles whereby IDEA only picked up the compiler settings for the
first set of modules.