### PR TITLE
IDEA: Set the JavaDoc and source paths on compiler libraries

### DIFF
--- a/src/main/scala/seed/generation/Idea.scala
+++ b/src/main/scala/seed/generation/Idea.scala
@@ -145,7 +145,7 @@ object Idea {
           scalaVersion,
           List(),
           List(),
-          optionalArtefacts = false
+          optionalArtefacts = true
         )
 
         val xml = IdeaFile.createLibrary(
@@ -158,8 +158,10 @@ object Idea {
               )
             ),
             classes = scalaCompiler.libraries.map(_.libraryJar.toString),
-            javaDoc = List(),
-            sources = List()
+            javaDoc =
+              scalaCompiler.libraries.flatMap(_.javaDocJar).map(_.toString),
+            sources =
+              scalaCompiler.libraries.flatMap(_.sourcesJar).map(_.toString)
           )
         )
 

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -246,10 +246,14 @@ object IdeaSpec extends SimpleTestSuite {
       scalaLibrary2_11_11.byTagAll["language-level"].map(_.toText),
       List("Scala_2_11")
     )
+    assert(scalaLibrary2_11_11.byTag["JAVADOC"].byTagOpt["root"].isDefined)
+    assert(scalaLibrary2_11_11.byTag["SOURCES"].byTagOpt["root"].isDefined)
     assertEquals(
       scalaLibrary2_12_8.byTagAll["language-level"].map(_.toText),
       List("Scala_2_12")
     )
+    assert(scalaLibrary2_12_8.byTag["JAVADOC"].byTagOpt["root"].isDefined)
+    assert(scalaLibrary2_12_8.byTag["SOURCES"].byTagOpt["root"].isDefined)
 
     val module211 =
       pine.XmlParser.fromString(


### PR DESCRIPTION
When following functions defined in the standard library, IDEA
should show their source code as with regular library dependencies.