### PR TITLE
IDEA: Fix generation of non-JVM projects

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
   - name: test
     image: alpine:3.10
     commands:
-      - apk add --no-cache openjdk8 python curl nodejs
+      - apk add --no-cache openjdk8 python curl nodejs clang libc-dev libunwind-dev g++
       - curl -L https://github.com/scalacenter/bloop/releases/download/v$(cat BLOOP)/install.py | python - -d bloop
       - export PATH=$(pwd)/bloop:$PATH
       - blp-server &

--- a/src/main/scala/seed/generation/Bloop.scala
+++ b/src/main/scala/seed/generation/Bloop.scala
@@ -280,7 +280,11 @@ object Bloop {
 
       val nativeLibDep = ArtefactResolution.nativeLibraryDep(native)
       val scalaNativelib = resolvedDeps
-        .find(_.javaDep == nativeLibDep)
+        .find(
+          d =>
+            d.javaDep.organisation == nativeLibDep.organisation &&
+              d.javaDep.artefact == nativeLibDep.artefact
+        )
         .map(_.libraryJar)
         .get
 
@@ -443,7 +447,7 @@ object Bloop {
     optionalArtefacts: Boolean,
     log: Log
   ): Unit = {
-    val isCrossBuild = module.targets.toSet.size > 1
+    val isCrossBuild = BuildConfig.isCrossBuild(module)
 
     val jsOutputPath =
       module.js.map(js => moduleOutputPath(buildPath, js, name + ".js"))

--- a/test/shared-module/base/js/src/Platform.scala
+++ b/test/shared-module/base/js/src/Platform.scala
@@ -1,0 +1,1 @@
+object Platform { val name = "js" }

--- a/test/shared-module/base/native/src/Platform.scala
+++ b/test/shared-module/base/native/src/Platform.scala
@@ -1,0 +1,1 @@
+object Platform { val name = "native" }

--- a/test/shared-module/build.toml
+++ b/test/shared-module/build.toml
@@ -1,0 +1,29 @@
+[project]
+scalaVersion       = "2.11.11"
+scalaJsVersion     = "0.6.28"
+scalaNativeVersion = "0.3.7"
+
+[module.base]
+root    = "base/"
+targets = ["js", "native"]
+
+[module.base.js]
+scalaVersion = "2.12.8"
+root         = "base/js/"
+sources      = ["base/js/src/"]
+
+[module.base.native]
+root    = "base/native/"
+sources = ["base/native/src/"]
+
+[module.example]
+moduleDeps = ["base"]
+root       = "example/"
+sources    = ["example/shared/src/"]
+targets    = ["js", "native"]
+scalaDeps  = [["com.lihaoyi", "sourcecode", "0.1.5"]]
+
+[module.example.js]
+scalaVersion = "2.12.8"
+root         = "example/js/"
+sources      = ["example/js/src/"]

--- a/test/shared-module/example/shared/src/Main.scala
+++ b/test/shared-module/example/shared/src/Main.scala
@@ -1,0 +1,1 @@
+object Main extends App { println(Platform.name) }


### PR DESCRIPTION
The project generation assumed that cross-platform modules are
compatible with the JVM, though this is not necessarily the case.
Instead, choose a valid platform from the `targets` setting.

Changes:
- Set up correct dependencies between IDEA modules, taking into
  account that not every Seed module has a corresponding IDEA module
- Do not reference invalid IDEA modules in compiler settings
- Generate IDEA modules that lack sources, but have a root path set
- Bloop: Compile and run a Scala Native program