### PR TITLE
Implement BSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This downloads all dependencies to `$HOME/.coursier` and creates projects for ID
 The final step is to compile and run your program:
 
 ```shell
-$ bloop run demo
+$ seed run demo
 ```
 
 This compiles the module to `build/` and runs it.
@@ -148,6 +148,7 @@ This compiles the module to `build/` and runs it.
     * True colour output
     * User-friendly messages
     * Unicode characters
+    * Progress bars
 * Project creation wizard
 * Packaging support
     * Copy over dependencies
@@ -675,6 +676,9 @@ level = "debug"
 
 # Use Unicode characters to indicate log levels
 unicode = true
+
+# Show progress bars when compiling modules
+progress = true
 ```
 
 The default values are indicated.
@@ -714,7 +718,28 @@ This approach is easier to manage in CI setups as Git modules track a specific c
 ## Usage
 Seed delegates the compilation phase to an external tool. Bloop is an intuitive build server that runs on the same machine as a background service. Its architectural design allows for shorter compilation cycles and lower overall memory consumption when working on multiple projects at the same time.
 
-After having run `seed bloop`, the following Bloop commands can be used:
+### Building, linking and running
+After having created a Bloop project with `seed bloop`, you can compile, link and run modules directly from Seed:
+* `seed build <module>`  This will compile all platform modules
+* `seed link <module>`   This will link all platform modules which support linking (JavaScript and Native)
+* `seed run <module>`    This will run a compatible platform module (JVM, JavaScript and Native)
+
+You can select a specific platform:
+* `seed build <module>:js`  This will compile only the JavaScript module
+* `seed link <module>:js`   This will link only the JavaScript module
+* `seed run <module>:js`    This will run only the JavaScript module
+
+If you defined a [custom build target](#custom-build-targets), you can use the same syntax to build it:
+* `seed build <module>:<target>`
+
+If you run Seed in [server mode](#server-mode), you can connect to your remote Seed instance using the `--connect` parameter:
+* `seed build --connect <module>` Trigger compilation on remote Seed instance
+* `seed link --connect <module>`  Trigger linking on remote Seed instance
+* `seed run --connect <module>`   Trigger running on remote Seed instance
+
+Also, run `seed --help` to acquaint yourself with all the available commands.
+
+As Seed creates a regular Bloop project, the official Bloop CLI can be used as well:
 
 ```shell
 bloop compile <module>      # Compile module
@@ -724,25 +749,6 @@ bloop test <module>         # Run test cases
 ```
 
 For more detailed information, please refer to the official [Bloop user guide](https://scalacenter.github.io/bloop/).
-
-Also, run `seed --help` to acquaint yourself with all the available commands.
-
-### Compiling and Linking
-After having created the Bloop project, you can compile and link it directly from Seed:
-* `seed build <module>`  This will compile all platform modules
-* `seed link <module>`   This will link all platform modules which support linking (JavaScript and Native)
-
-You can select a specific platform:
-* `seed build <module>:js`  This will compile only the JavaScript module
-* `seed link <module>:js`   This will link only the JavaScript module
-
-If you defined a [custom build target](#custom-build-targets), you can use the same syntax to build it:
-* `seed build <module>:<target>`
-
-If you run Seed in [server mode](#server-mode), you can connect to your remote Seed instance using the `--connect` parameter:
-
-* `seed build --connect <module>` Trigger compilation on remote Seed instance
-* `seed link --connect <module>`  Trigger linking on remote Seed instance
 
 ### Server mode
 You can run Seed in server mode. By default, it will listen to JSON commands on the WebSocket server `localhost:8275`. It supports several commands:
@@ -822,10 +828,9 @@ As a workaround, you can open a terminal within IntelliJ and use Bloop, for exam
 ## Packaging
 In order to distribute your project, you may want to package the compiled sources. The approach chosen in Seed is to bundle them as a JAR file.
 
-To package the module `demo`, use the following commands:
+To build and package the module `demo`, use the following command:
 
 ```shell
-bloop compile demo
 seed package demo
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,22 +41,28 @@ Compile / sourceGenerators += Def.task {
 }.taskValue
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi"           %% "fansi"          % "0.2.7",
-  "io.get-coursier"       %% "coursier"       % bloopCoursierVersion,
-  "io.get-coursier"       %% "coursier-cache" % bloopCoursierVersion,
-  "tech.sparse"           %% "toml-scala"     % "0.2.0",
-  "tech.sparse"           %% "pine"           % "0.1.4",
-  "ch.epfl.scala"         %% "bloop-config"   % bloopVersion,
-  "com.joefkelley"        %% "argyle"         % "1.0.0",
-  "org.scalaj"            %% "scalaj-http"    % "2.4.2",
-  "dev.zio"               %% "zio"            % "1.0.0-RC10-1",
-  "io.circe"              %% "circe-core"     % "0.11.1",
-  "commons-io"            % "commons-io"      % "2.6",
-  "com.zaxxer"            % "nuprocess"       % "1.2.4",
-  "org.java-websocket"    % "Java-WebSocket"  % "1.4.0",
-  "org.slf4j"             % "slf4j-simple"    % "2.0.0-alpha0",
-  "io.monix"              %% "minitest"       % "2.5.0" % "test",
-  scalaOrganization.value % "scala-reflect"   % scalaVersion.value
+  "com.lihaoyi"                  %% "fansi"            % "0.2.7",
+  "io.get-coursier"              %% "coursier"         % bloopCoursierVersion,
+  "io.get-coursier"              %% "coursier-cache"   % bloopCoursierVersion,
+  "tech.sparse"                  %% "toml-scala"       % "0.2.0",
+  "tech.sparse"                  %% "pine"             % "0.1.4",
+  "ch.epfl.scala"                %% "bloop-config"     % bloopVersion,
+  "ch.epfl.scala"                % "bsp4j"             % "2.0.0-M4",
+  "ch.epfl.scala"                % "directory-watcher" % "0.8.0+6-f651bd93",
+  "com.joefkelley"               %% "argyle"           % "1.0.0",
+  "org.scalaj"                   %% "scalaj-http"      % "2.4.2",
+  "dev.zio"                      %% "zio"              % "1.0.0-RC14",
+  "dev.zio"                      %% "zio-streams"      % "1.0.0-RC14",
+  "io.circe"                     %% "circe-core"       % "0.11.1",
+  "io.circe"                     %% "circe-generic"    % "0.11.1",
+  "io.circe"                     %% "circe-parser"     % "0.11.1",
+  "commons-io"                   % "commons-io"        % "2.6",
+  "com.zaxxer"                   % "nuprocess"         % "1.2.4",
+  "org.java-websocket"           % "Java-WebSocket"    % "1.4.0",
+  "org.slf4j"                    % "slf4j-simple"      % "1.7.25",
+  "com.kohlschutter.junixsocket" % "junixsocket-core"  % "2.2.0",
+  "io.monix"                     %% "minitest"         % "2.5.0" % "test",
+  scalaOrganization.value        % "scala-reflect"     % scalaVersion.value
 )
 
 run / fork := true

--- a/etc/seed.toml
+++ b/etc/seed.toml
@@ -1,2 +1,9 @@
+#
+# These settings are used by the Docker image
+#
+
+[cli]
+progress = false
+
 [resolution]
 silent = true

--- a/src/main/scala/seed/Log.scala
+++ b/src/main/scala/seed/Log.scala
@@ -1,16 +1,20 @@
 package seed
 
 import seed.cli.util.Ansi._
+import seed.cli.util.Colour
 import seed.cli.util.ColourScheme._
 
 class Log(
-  f: String => Unit,
-  map: String => String,
+  val f: String => Unit,
+  val map: String => String,
   val level: LogLevel,
   val unicode: Boolean
 ) {
   import Log._
   import LogLevel._
+
+  def filter(f: String => Boolean): Log =
+    new Log(m => if (f(m)) this.f(m), map, level, unicode)
 
   def prefix(text: String): Log = new Log(f, text + _, level, unicode)
 
@@ -22,11 +26,11 @@ class Log(
         )
       )
 
-  def detail(message: String): Unit =
+  def detail(message: String, colour: Colour = blue3): Unit =
     if (level <= Detail)
       f(
         (" " * (if (unicode) UnicodeLength else NonUnicodeLength)) +
-          foreground(blue3)(map(message))
+          foreground(colour)(map(message))
       )
 
   def info(message: String): Unit =
@@ -34,6 +38,14 @@ class Log(
       f(
         foreground(blue2)(
           bold(if (unicode) "ⓘ " else " [info] ") + map(message)
+        )
+      )
+
+  def infoRetainColour(message: String): Unit =
+    if (level <= Info)
+      f(
+        foreground(blue2)(bold(if (unicode) "ⓘ " else " [info] ")) + map(
+          message
         )
       )
 
@@ -60,8 +72,8 @@ sealed abstract class LogLevel(val index: Int) extends Ordered[LogLevel] {
 
 object LogLevel {
   case object Debug  extends LogLevel(0)
-  case object Detail extends LogLevel(1)
-  case object Info   extends LogLevel(2)
+  case object Info   extends LogLevel(1)
+  case object Detail extends LogLevel(2)
   case object Warn   extends LogLevel(3)
   case object Error  extends LogLevel(4)
   case object Silent extends LogLevel(5)

--- a/src/main/scala/seed/build/Bloop.scala
+++ b/src/main/scala/seed/build/Bloop.scala
@@ -1,0 +1,639 @@
+package seed.build
+
+import java.net.Socket
+import java.util.concurrent.{
+  CompletableFuture,
+  Executor,
+  Executors,
+  RejectedExecutionException,
+  TimeUnit
+}
+
+import com.google.gson.JsonObject
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import seed.cli.util.{
+  Ansi,
+  BloopCli,
+  ColourScheme,
+  ConsoleOutput,
+  ProgressBar,
+  Watcher
+}
+import ch.epfl.scala.bsp4j._
+import com.google.gson.{Gson, JsonElement}
+
+import scala.collection.{JavaConverters, mutable}
+import java.nio.file.{Files, Path}
+
+import org.newsclub.net.unix.{AFUNIXSocket, AFUNIXSocketAddress}
+import seed.Log
+import seed.config.BuildConfig
+import seed.config.BuildConfig.Build
+import seed.generation.util.PathUtil
+import seed.process.ProcessHelper
+import seed.model.{BuildEvent, Platform}
+import zio._
+import zio.clock.Clock
+import zio.stream._
+import zio.duration._
+
+import scala.concurrent.CancellationException
+
+class BloopClient(
+  consoleOutput: ConsoleOutput,
+  progress: Boolean,
+  projectPath: Path,
+  build: Build,
+  allModules: List[(String, Platform)],
+  onBuildEvent: BuildEvent => Unit
+) extends BuildClient {
+  import consoleOutput.log
+
+  private val gson: Gson = new Gson()
+
+  // Cannot use ListMap here since updating it changes the order of the elements
+  private val modules = mutable.ListBuffer[(String, ProgressBar.Line)]()
+  reset()
+
+  def reset(): Unit = {
+    modules.clear()
+    modules ++= allModules.map {
+      case (m, p) =>
+        BuildConfig.targetName(build, m, p) -> ProgressBar
+          .Line(
+            0,
+            ProgressBar.Result.Waiting,
+            m + " (" + p.caption + ")",
+            0,
+            0
+          )
+    }
+
+    lastDiagnosticFilePath = ""
+  }
+
+  /** Modules compiled, the upcoming notifications are related to running */
+  def compiled: Boolean = consoleOutput.isFlushed
+
+  def printPb(): Unit =
+    if (!compiled && progress)
+      consoleOutput.write(ProgressBar.printAll(modules), sticky = true)
+
+  def updatePb(): Unit = {
+    modules.zipWithIndex.foreach {
+      case ((id, line), i) =>
+        modules.update(i, id -> line.copy(tick = line.tick + 1))
+    }
+
+    printPb()
+  }
+
+  override def onBuildShowMessage(params: ShowMessageParams): Unit = {
+    require(!params.getMessage.endsWith("\n"))
+    log.infoRetainColour("[build] " + params.getMessage)
+  }
+
+  override def onBuildLogMessage(params: LogMessageParams): Unit =
+    // Compilation failures of modules is already indicated in the progress bar
+    if (!params.getMessage.startsWith("Failed to compile ") &&
+        !params.getMessage.startsWith("Deduplicating compilation of ")) {
+      require(!params.getMessage.endsWith("\n"))
+      log.infoRetainColour(params.getMessage)
+      printPb()
+    }
+
+  import scala.collection.JavaConverters._
+
+  private var lastDiagnosticFilePath = ""
+
+  override def onBuildPublishDiagnostics(
+    params: PublishDiagnosticsParams
+  ): Unit = {
+    val uri     = params.getBuildTarget.getUri
+    val bloopId = uri.split('\u003d').last
+    val parsed  = BloopCli.parseBloopModule(build, bloopId)
+    val id      = Ansi.italic(parsed._1)
+
+    val absolutePath =
+      params.getTextDocument.getUri.stripPrefix("file://")
+
+    val filePath =
+      Ansi.bold(
+        if (absolutePath.startsWith(projectPath.toString))
+          absolutePath.drop(projectPath.toAbsolutePath.toString.length + 1)
+        else
+          absolutePath
+      )
+
+    params.getDiagnostics.asScala.foreach { diag =>
+      val lines = diag.getMessage.linesIterator.toList
+      val lineInfo =
+        s"[${diag.getRange.getStart.getLine}:${diag.getRange.getStart.getCharacter}]: "
+      val message = lineInfo + lines.head
+
+      if (diag.getSeverity == DiagnosticSeverity.ERROR) {
+        if (filePath != lastDiagnosticFilePath) log.error(filePath + s" ($id)")
+        log.detail(message, ColourScheme.red2)
+        lines.tail.foreach(
+          l => log.detail((" " * lineInfo.length) + l, ColourScheme.red2)
+        )
+      } else if (diag.getSeverity == DiagnosticSeverity.INFORMATION || diag.getSeverity == DiagnosticSeverity.HINT) {
+        if (filePath != lastDiagnosticFilePath) log.info(filePath + s" ($id)")
+        log.detail(message, ColourScheme.blue2)
+        lines.tail.foreach(l => log.detail((" " * lineInfo.length) + l))
+      } else if (diag.getSeverity == DiagnosticSeverity.WARNING) {
+        if (filePath != lastDiagnosticFilePath) log.warn(filePath + s" ($id)")
+        log.detail(message, ColourScheme.yellow2)
+        lines.tail.foreach(
+          l => log.detail((" " * lineInfo.length) + l, ColourScheme.yellow2)
+        )
+      }
+    }
+
+    lastDiagnosticFilePath = filePath
+    printPb()
+  }
+
+  override def onBuildTargetDidChange(params: DidChangeBuildTarget): Unit = ()
+
+  override def onBuildTaskStart(params: TaskStartParams): Unit =
+    if (!compiled) {
+      val uri = params.getData
+        .asInstanceOf[JsonObject]
+        .get("target")
+        .asInstanceOf[JsonObject]
+        .get("uri")
+        .getAsString
+      val bloopId = uri.split('\u003d').last
+      val parsed  = BloopCli.parseBloopModule(build, bloopId)
+      onBuildEvent(BuildEvent.Compiling(parsed._1, parsed._2))
+    }
+
+  override def onBuildTaskProgress(params: TaskProgressParams): Unit = {
+    val uri = params.getData
+      .asInstanceOf[JsonObject]
+      .get("target")
+      .asInstanceOf[JsonObject]
+      .get("uri")
+      .getAsString
+    val bloopId = uri.split('\u003d').last
+
+    val index = modules.indexWhere(_._1 == bloopId)
+    if (index != -1) {
+      modules.update(
+        index,
+        bloopId -> modules(index)._2.copy(
+          result = ProgressBar.Result.InProgress,
+          step = params.getProgress.toInt,
+          total = params.getTotal.toInt
+        )
+      )
+
+      printPb()
+    }
+  }
+
+  override def onBuildTaskFinish(params: TaskFinishParams): Unit =
+    params.getDataKind match {
+      case TaskDataKind.COMPILE_REPORT =>
+        val json   = params.getData.asInstanceOf[JsonElement]
+        val report = gson.fromJson[CompileReport](json, classOf[CompileReport])
+
+        val uri     = report.getTarget.getUri
+        val bloopId = uri.split('\u003d').last
+        val parsed  = BloopCli.parseBloopModule(build, bloopId)
+
+        val r =
+          if (report.getErrors == 0) {
+            if (report.getWarnings > 0)
+              ProgressBar.Result.Warnings
+            else
+              ProgressBar.Result.Success
+          } else ProgressBar.Result.Failure
+
+        val index = modules.indexWhere(_._1 == bloopId)
+        if (index != -1) {
+          if (report.getErrors == 0) {
+            if (!compiled)
+              onBuildEvent(BuildEvent.Compiled(parsed._1, parsed._2))
+            modules.update(
+              index,
+              bloopId -> modules(index)._2
+                .copy(result = r, step = 100, total = 100)
+            )
+
+            if (progress) printPb()
+            else log.info("Module " + Ansi.italic(parsed._1) + " compiled")
+          } else {
+            if (!compiled) onBuildEvent(BuildEvent.Failed(parsed._1, parsed._2))
+            modules.update(index, bloopId -> modules(index)._2.copy(result = r))
+
+            if (progress) printPb()
+            else
+              log.error(
+                "Module " + Ansi.italic(parsed._1) + " could not be compiled"
+              )
+          }
+        }
+
+      case TaskDataKind.TEST_REPORT =>
+        val json   = params.getData.asInstanceOf[JsonElement]
+        val report = gson.fromJson[TestReport](json, classOf[TestReport])
+      // TODO implement
+
+      case _ =>
+    }
+}
+
+trait BloopServer extends BuildServer with ScalaBuildServer
+
+class BspProcess(socketPath: Path, val fiber: Fiber[Nothing, Unit]) {
+  def await(): IO[Nothing, Unit] = fiber.join
+
+  // Bloop does not remove the socket file when the server stops
+  def deleteSocketFile(): UIO[Unit] = UIO(Files.deleteIfExists(socketPath))
+}
+
+object Bsp {
+  def connect(
+    client: BloopClient,
+    socket: Socket,
+    projectPath: Path
+  ): BloopServer = {
+    val es = Executors.newCachedThreadPool()
+
+    val launcher = new Launcher.Builder[BloopServer]()
+      .setRemoteInterface(classOf[BloopServer])
+      .setExecutorService(es)
+      .setInput(socket.getInputStream)
+      .setOutput(socket.getOutputStream)
+      .setLocalService(client)
+      .create()
+
+    launcher.startListening()
+
+    val server = launcher.getRemoteProxy
+    client.onConnectWithServer(server)
+
+    val bspVersion = "2.0.0-M4"
+
+    import seed.BuildInfo
+
+    val initialiseParams =
+      new InitializeBuildParams(
+        "bloop",
+        BuildInfo.Bloop,
+        bspVersion,
+        projectPath.toUri.toString,
+        new BuildClientCapabilities(java.util.Arrays.asList("scala"))
+      )
+
+    server.buildInitialize(initialiseParams).get()
+    server.onBuildInitialized()
+    server
+  }
+
+  def shutdown(
+    bspProcess: BspProcess,
+    socket: Socket,
+    server: BloopServer
+  ): UIO[Unit] =
+    for {
+      _ <- fromCompletableFuture(server.buildShutdown()).ignore
+      _ <- UIO(socket.close())
+      _ <- bspProcess.await()
+      _ <- bspProcess.deleteSocketFile()
+    } yield ()
+
+  def scalacOptions(
+    server: BloopServer,
+    build: Build,
+    projectPath: Path,
+    allModules: List[(String, Platform)]
+  ): Task[ScalacOptionsResult] = {
+    val params =
+      new ScalacOptionsParams(
+        JavaConverters
+          .seqAsJavaListConverter(allModules.map {
+            case (m, p) =>
+              val id = BuildConfig.targetName(build, m, p)
+              new BuildTargetIdentifier(
+                s"file://${projectPath.toAbsolutePath}/?id=$id"
+              )
+          })
+          .asJava
+      )
+
+    fromCompletableFuture(server.buildTargetScalacOptions(params))
+  }
+
+  def classDirectories(
+    server: BloopServer,
+    build: Build,
+    projectPath: Path,
+    allModules: List[(String, Platform)]
+  ): Task[Map[(String, Platform), String]] = {
+    val bloopModuleMap = allModules.map {
+      case (m, p) =>
+        val id = BuildConfig.targetName(build, m, p)
+        s"file://${projectPath.toAbsolutePath}/?id=$id" -> (m, p)
+    }.toMap
+
+    scalacOptions(server, build, projectPath, allModules).map { result =>
+      import JavaConverters._
+      result.getItems.asScala.map { item =>
+        bloopModuleMap(item.getTarget.getUri) -> item.getClassDirectory
+          .stripPrefix("file://")
+      }.toMap
+    }
+  }
+
+  def buildModules(
+    server: BloopServer,
+    build: Build,
+    projectPath: Path,
+    allModules: List[(String, Platform)]
+  ): Task[CompileResult] = {
+    val compileParams =
+      new CompileParams(
+        JavaConverters
+          .seqAsJavaListConverter(allModules.map {
+            case (m, p) =>
+              val id = BuildConfig.targetName(build, m, p)
+              new BuildTargetIdentifier(
+                s"file://${projectPath.toAbsolutePath}/?id=$id"
+              )
+          })
+          .asJava
+      )
+
+    fromCompletableFuture(server.buildTargetCompile(compileParams))
+  }
+
+  def runModule(
+    client: BloopClient,
+    server: BloopServer,
+    build: Build,
+    projectPath: Path,
+    consoleOutput: ConsoleOutput,
+    module: String,
+    platform: Platform,
+    progress: Boolean
+  ): UIO[Unit] =
+    for {
+      _ <- compile(
+        client,
+        server,
+        consoleOutput,
+        progress,
+        build,
+        projectPath,
+        List(module -> platform)
+      )
+      _ <- {
+        val id = BuildConfig.targetName(build, module, platform)
+        val target = new BuildTargetIdentifier(
+          s"file://${projectPath.toAbsolutePath}/?id=$id"
+        )
+        fromCompletableFuture(server.buildTargetRun(new RunParams(target))).option
+          .map(_.map(_.getStatusCode))
+      }
+    } yield ()
+
+  def fromCompletableFuture[T](future: => CompletableFuture[T]): Task[T] =
+    Task.descriptorWith(
+      d =>
+        ZIO
+          .effect(future)
+          .flatMap(
+            f =>
+              Task
+                .effectAsync { (cb: Task[T] => Unit) =>
+                  f.whenCompleteAsync(
+                    (v: T, e: Throwable) =>
+                      if (e == null) cb(Task.succeed(v))
+                      else {
+                        if (!e.isInstanceOf[CancellationException]) {
+                          e.printStackTrace()
+                          cb(Task.fail(e))
+                        }
+                      },
+                    new Executor {
+                      override def execute(r: Runnable): Unit =
+                        if (!d.executor.submit(r))
+                          throw new RejectedExecutionException(
+                            "Rejected: " + r.toString
+                          )
+                    }
+                  )
+                }
+                .onTermination { _ =>
+                  if (!f.isDone) f.cancel(true)
+                  UIO(())
+                }
+          )
+    )
+
+  def runBspServer(
+    projectPath: Path,
+    log: Log,
+    onStdOut: String => Unit
+  ): (Path, UIO[Unit]) = {
+    val socketPath = PathUtil.TemporaryFolder.resolve(
+      "seed-bsp-" + System.currentTimeMillis() + ".socket"
+    )
+    val process = ProcessHelper.runBloop(projectPath, log, onStdOut)(
+      "bsp",
+      "--socket",
+      socketPath.toString
+    )
+    (socketPath, process)
+  }
+
+  def establishBspConnection(
+    log: Log,
+    socketPath: Path
+  ): ZIO[Any with Clock, Throwable, AFUNIXSocket] = {
+    val socket = AFUNIXSocket.newInstance()
+    IO {
+      log.debug("Connecting to BSP...")
+      socket.connect(new AFUNIXSocketAddress(socketPath.toFile))
+      socket
+    }.retry(Schedule.exponential(Duration(50, TimeUnit.MILLISECONDS)))
+  }
+
+  def runBspServerAndConnect(
+    client: BloopClient,
+    projectPath: Path,
+    log: Log
+  ): ZIO[Any, Nothing, (BspProcess, Socket, BloopServer)] = {
+    val (bspSocketPath, bspProcess) = runBspServer(
+      projectPath,
+      new Log(log.f, log.map, log.level, log.unicode) {
+        override def error(message: String): Unit =
+          // This message is printed to stderr, but it is not an error, therefore
+          // change log level to 'debug'
+          if (message.contains("BSP server cancelled, closing socket..."))
+            // Remove "[E] " from message
+            debug(message.dropWhile(_ != ' ').tail)
+          else
+            super.error(message)
+      },
+      message => log.debug(Ansi.bold("[BSP] ") + message)
+    )
+
+    var connectionFiber: Option[Fiber[Throwable, AFUNIXSocket]] = None
+
+    // Interrupt connection fiber if `bloop bsp` failed (i.e. the Bloop server
+    // was not started)
+    def interrupt: ZIO[Any, Nothing, Any] =
+      connectionFiber.map(_.interrupt).getOrElse(UIO.unit)
+
+    val result = for {
+      process    <- bspProcess.onTermination(_ => interrupt).fork
+      connection <- establishBspConnection(log, bspSocketPath).fork
+      _ = connectionFiber = Some(connection)
+      socket <- connection.join
+    } yield (
+      new BspProcess(bspSocketPath, process),
+      socket,
+      Bsp.connect(client, socket, projectPath)
+    )
+
+    val runtime = new DefaultRuntime {}
+    result
+      .provide(runtime.Environment)
+      .either
+      .map(_.right.get)
+  }
+
+  def interruptIfParentFails[T](
+    parent: IO[Nothing, Unit],
+    child: UIO[T]
+  ): ZIO[Any, Nothing, T] =
+    for {
+      f <- child.fork
+      _ <- parent.onInterrupt(f.interrupt)
+      r <- f.join
+    } yield r
+
+  private def progressBarUpdater(
+    client: BloopClient,
+    consoleOutput: ConsoleOutput
+  ) = {
+    val effect    = RIO.effect(client.updatePb())
+    val scheduler = Schedule.spaced(150.millis)
+    val runtime   = new DefaultRuntime {}
+
+    Stream
+      .fromEffect(effect)
+      .repeat(scheduler)
+      .provide(runtime.Environment)
+      .runDrain
+      .fork
+  }
+
+  def withProgressBar(
+    client: BloopClient,
+    consoleOutput: ConsoleOutput,
+    zio: ZIO[Any, Nothing, Option[StatusCode]]
+  ): ZIO[Any, Nothing, Unit] =
+    UIO(client.printPb()).flatMap(
+      _ =>
+        progressBarUpdater(client, consoleOutput).flatMap(
+          pb =>
+            zio.flatMap(
+              result =>
+                for {
+                  _ <- pb.interrupt.map(_ => ())
+                  _ <- UIO(consoleOutput.flushSticky())
+                  _ <- if (result.exists(_ != StatusCode.OK)) IO.interrupt
+                  else IO.unit
+                } yield ()
+            )
+        )
+    )
+
+  def compile(
+    client: BloopClient,
+    server: BloopServer,
+    consoleOutput: ConsoleOutput,
+    progress: Boolean,
+    build: Build,
+    projectPath: Path,
+    bloopModules: List[(String, Platform)]
+  ): UIO[Unit] = {
+    consoleOutput.log.info(
+      s"Compiling ${Ansi.bold(bloopModules.length.toString)} modules..."
+    )
+
+    val b = Bsp
+      .buildModules(server, build, projectPath, bloopModules)
+      .option
+      .map(_.map(_.getStatusCode))
+
+    if (progress) withProgressBar(client, consoleOutput, b)
+    else
+      b.flatMap(
+        result =>
+          if (result.exists(_ != StatusCode.OK)) IO.interrupt else IO.unit
+      )
+  }
+
+  def watchAction(
+    build: Build,
+    client: BloopClient,
+    consoleOutput: ConsoleOutput,
+    resolvedModules: List[(String, Platform)],
+    action: UIO[Unit],
+    wait: Boolean,
+    runInitially: Boolean
+  ): UIO[Unit] = {
+    import consoleOutput.log
+
+    val allSourcePaths = BuildConfig.sourcePaths(build, resolvedModules)
+
+    // Otherwise, the watcher will throw an exception
+    val sourcePaths = allSourcePaths.filter(Files.exists(_))
+
+    val runtime = new DefaultRuntime {}
+
+    var current: Option[Fiber[Nothing, Unit]] = None
+
+    for {
+      _ <- UIO {
+        log.info(
+          s"Watching ${Ansi.bold(sourcePaths.length.toString)} source paths..."
+        )
+        sourcePaths.foreach(path => log.debug(path.toString))
+      }
+      r <- if (runInitially) action.ignore.fork.map(Some(_)) else UIO(None)
+      _ = current = r
+      _ <- Watcher
+        .watchPaths(sourcePaths)
+        .throttleEnforce(1, 3.seconds)(_ => 1)
+        .aggregate(Sink.drain)
+        .foreach { _ =>
+          for {
+            _ <- current match {
+              case None => UIO(())
+              case Some(c) => if (wait) c.join else c.interrupt.map(_ => ())
+            }
+
+            // Reset must happen after Fiber has been interrupted, otherwise all
+            // progress bars will be reset to 0.
+            _ <- UIO(client.reset())
+            _ <- UIO(consoleOutput.reset())
+
+            r <- action.ignore.fork
+            _ <- {
+              current = Some(r)
+              UIO(())
+            }
+          } yield r
+        }
+        .ignore
+        .provide(runtime.Environment)
+    } yield ()
+  }
+}

--- a/src/main/scala/seed/cli/Run.scala
+++ b/src/main/scala/seed/cli/Run.scala
@@ -1,0 +1,181 @@
+package seed.cli
+
+import java.net.URI
+import java.nio.file.Path
+
+import seed.Log
+import seed.cli.util.{Ansi, ConsoleOutput, RTS, WsClient}
+import seed.config.BuildConfig
+import seed.model.{BuildEvent, Config}
+import seed.Cli.Command
+import seed.build.{BloopClient, Bsp}
+import zio._
+
+object Run {
+  def ui(
+    buildPath: Path,
+    seedConfig: Config,
+    command: Command.Run,
+    log: Log
+  ): Unit =
+    command.webSocket match {
+      case Some(connection) =>
+        if (command.watch)
+          log.error("--watch cannot be combined with --connect")
+        else {
+          val uri = s"ws://${connection.host}:${connection.port}"
+          log.debug(s"Connecting to ${Ansi.italic(uri)}...")
+          val client = new WsClient(new URI(uri), { () =>
+            import io.circe.syntax._
+            val build =
+              if (buildPath.isAbsolute) buildPath else buildPath.toAbsolutePath
+            (WsCommand.Run(build, command.module): WsCommand).asJson.noSpaces
+          }, log)
+          client.connect()
+        }
+
+      case None =>
+        val tmpfs    = command.packageConfig.tmpfs || seedConfig.build.tmpfs
+        val progress = seedConfig.cli.progress
+        run(
+          buildPath,
+          command.module,
+          command.watch,
+          tmpfs,
+          progress,
+          log,
+          print,
+          _ => ()
+        ) match {
+          case Left(errors) =>
+            errors.foreach(log.error)
+            sys.exit(1)
+          case Right(uio) =>
+            val result = RTS.unsafeRunSync(uio)
+            sys.exit(if (result.succeeded) 0 else 1)
+        }
+    }
+
+  def run(
+    buildPath: Path,
+    module: String,
+    watch: Boolean,
+    tmpfs: Boolean,
+    progress: Boolean,
+    log: Log,
+    onStdOut: String => Unit,
+    onBuildEvent: BuildEvent => Unit
+  ): Either[List[String], UIO[Unit]] =
+    BuildConfig.load(buildPath, log) match {
+      case None => Left(List())
+      case Some(result) =>
+        import result.{build, projectPath}
+
+        val parsedModule = util.Target.parseModuleString(result.build)(module)
+
+        util.Validation.unpack(List(parsedModule)).right.flatMap { allModules =>
+          val module = allModules.head
+
+          module match {
+            case util.Target.Parsed(module, None)
+                if module.module.targets.length > 1 =>
+              Left(List("Ambiguous platform target"))
+            case util.Target.Parsed(_, Some(Right(_))) =>
+              Left(List("Invalid platform target specified"))
+            case _ =>
+              val processes = seed.cli.BuildTarget.buildTargets(
+                build,
+                List(module),
+                projectPath,
+                watch,
+                tmpfs,
+                log
+              )
+
+              val runModule = module match {
+                case util.Target.Parsed(module, None) =>
+                  val platform = module.module.targets.head
+                  Some((module.name, platform))
+                case util.Target.Parsed(module, Some(Left(platform))) =>
+                  Some((module.name, platform))
+                case util.Target.Parsed(_, Some(Right(_))) => None
+              }
+
+              runModule match {
+                case None => Right(ZIO.unit)
+                case Some((module, platform)) =>
+                  val expandedModules =
+                    BuildConfig.expandModules(build, List(module -> platform))
+                  val consoleOutput = new ConsoleOutput(log, onStdOut)
+
+                  val client = new BloopClient(
+                    consoleOutput,
+                    progress,
+                    projectPath,
+                    build,
+                    expandedModules,
+                    onBuildEvent
+                  )
+
+                  val program = Bsp
+                    .runBspServerAndConnect(
+                      client,
+                      projectPath,
+                      consoleOutput.log
+                    )
+                    .flatMap {
+                      case (bspProcess, socket, server) =>
+                        val run =
+                          Bsp.runModule(
+                            client,
+                            server,
+                            build,
+                            projectPath,
+                            consoleOutput,
+                            module,
+                            platform,
+                            progress
+                          )
+
+                        val program =
+                          if (!watch)
+                            run.ensuring(
+                              Bsp.shutdown(bspProcess, socket, server)
+                            )
+                          else
+                            Bsp.watchAction(
+                              build,
+                              client,
+                              consoleOutput,
+                              expandedModules,
+                              run,
+                              wait = false,
+                              runInitially = true
+                            )
+
+                        Bsp.interruptIfParentFails(
+                          bspProcess.fiber.join,
+                          program
+                        )
+                    }
+
+                  val await = processes.collect { case Left(p)  => p }
+                  val async = processes.collect { case Right(p) => p }
+
+                  if (await.nonEmpty)
+                    consoleOutput.log
+                      .info(
+                        s"Awaiting termination of ${await.length} processes..."
+                      )
+
+                  Right(
+                    for {
+                      _ <- ZIO.collectAllPar(await)
+                      _ <- ZIO.collectAllPar(async :+ program)
+                    } yield ()
+                  )
+              }
+          }
+        }
+    }
+}

--- a/src/main/scala/seed/cli/Server.scala
+++ b/src/main/scala/seed/cli/Server.scala
@@ -7,32 +7,47 @@ import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import org.java_websocket.WebSocket
 import seed.Log
-import seed.cli.util.{BloopCli, RTS, WsServer}
+import seed.cli.util.{RTS, WsServer}
 import seed.Cli.Command
-import seed.config.BuildConfig.Build
-import seed.model.Config
+import seed.model.{BuildEvent, Config}
+import zio.{Fiber, UIO}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 sealed abstract class WsCommand(val description: String)
 object WsCommand {
+  case class Run(build: Path, module: String) extends WsCommand("Run")
   case class Link(build: Path, modules: List[String], optimise: Boolean = false)
       extends WsCommand("Link")
   case class Build(build: Path, targets: List[String])
       extends WsCommand("Build")
   case object BuildEvents extends WsCommand("Build events")
 
-  implicit val decodeLink: Decoder[Link] = json =>
+  implicit val decodeRun: Decoder[Run] = json =>
     for {
       build   <- json.downField("build").as[String].map(Paths.get(_))
-      modules <- json.downField("modules").as[List[String]]
-    } yield Link(build, modules)
+      modules <- json.downField("module").as[String]
+    } yield Run(build, modules)
+
+  val encodeRun: Run => List[(String, Json)] = run =>
+    List(
+      "build"  -> Json.fromString(run.build.toString),
+      "module" -> implicitly[Encoder[String]].apply(run.module)
+    )
+
+  implicit val decodeLink: Decoder[Link] = json =>
+    for {
+      build    <- json.downField("build").as[String].map(Paths.get(_))
+      modules  <- json.downField("modules").as[List[String]]
+      optimise <- json.downField("optimise").as[Option[Boolean]]
+    } yield Link(build, modules, optimise.getOrElse(false))
 
   val encodeLink: Link => List[(String, Json)] = link =>
     List(
-      "build"   -> Json.fromString(link.build.toString),
-      "modules" -> implicitly[Encoder[List[String]]].apply(link.modules)
+      "build"    -> Json.fromString(link.build.toString),
+      "modules"  -> implicitly[Encoder[List[String]]].apply(link.modules),
+      "optimise" -> implicitly[Encoder[Boolean]].apply(link.optimise)
     )
 
   implicit val decodeBuild: Decoder[Build] = json =>
@@ -50,7 +65,8 @@ object WsCommand {
   implicit val decodeCommand: Decoder[WsCommand] = json =>
     for {
       commandName <- json.downField("command").as[String]
-      command <- if (commandName == "link") json.as[Link]
+      command <- if (commandName == "run") json.as[Run]
+      else if (commandName == "link") json.as[Link]
       else if (commandName == "build") json.as[Build]
       else if (commandName == "buildEvents") Right(BuildEvents)
       else Left(DecodingFailure(s"Invalid command: $commandName", json.history))
@@ -60,6 +76,10 @@ object WsCommand {
     case build: WsCommand.Build =>
       Json.fromFields(
         List("command" -> Json.fromString("build")) ++ encodeBuild(build)
+      )
+    case run: WsCommand.Run =>
+      Json.fromFields(
+        List("command" -> Json.fromString("run")) ++ encodeRun(run)
       )
     case link: WsCommand.Link =>
       Json.fromFields(
@@ -71,39 +91,56 @@ object WsCommand {
 }
 
 object Server {
+  private val fibers            = mutable.HashMap[WebSocket, Fiber[Nothing, Unit]]()
   private val buildEventClients = mutable.HashSet[WebSocket]()
 
   def ui(config: Config, command: Command.Server, log: Log): Unit = {
     val wsConfig = command.webSocket
     val webSocket = new WsServer(
       new InetSocketAddress(wsConfig.host, wsConfig.port),
-      onDisconnect,
+      onDisconnect(log),
       evalCommand(config, log),
       log
     )
     webSocket.start()
   }
 
-  def onStdOut(
-    wsServer: WsServer,
-    wsClient: WebSocket,
-    build: Build,
-    serverLog: Log
-  )(message: String): Unit = {
-    wsClient.send(message)
+  def onStdOut(wsClient: WebSocket)(message: String): Unit =
+    if (wsClient.isOpen) wsClient.send(message)
 
+  def onBroadcastBuildEvent(wsServer: WsServer, serverLog: Log)(
+    event: BuildEvent
+  ): Unit =
     if (buildEventClients.nonEmpty) {
-      val event = BloopCli.parseStdOut(build)(message)
-      event.foreach { ev =>
-        serverLog.debug(
-          s"Broadcasting event to ${buildEventClients.size} clients..."
-        )
-        wsServer.broadcast(ev.asJson.noSpaces, buildEventClients.toList.asJava)
-      }
+      serverLog.debug(
+        s"Broadcasting event to ${buildEventClients.size} clients..."
+      )
+      wsServer.broadcast(
+        event.asJson.noSpaces + "\n",
+        buildEventClients.toList.asJava
+      )
     }
+
+  def runCommandUio(uio: UIO[Unit], wsClient: WebSocket): Unit = {
+    val program = for {
+      fiber <- uio.fork
+      _ = fibers += wsClient -> fiber
+      _ <- fiber.await // TODO Send success state to client
+      _ <- UIO(fibers -= wsClient)
+      _ <- UIO(wsClient.close())
+    } yield ()
+
+    RTS.unsafeRunAsync(program)(_ => ())
   }
 
-  def onDisconnect(wsClient: WebSocket): Unit = buildEventClients -= wsClient
+  def onDisconnect(log: Log)(wsClient: WebSocket): Unit = {
+    fibers.get(wsClient).foreach { fiber =>
+      RTS.unsafeRunAsync(fiber.interrupt)(_ => log.info("Interrupted command"))
+      fibers -= wsClient
+    }
+
+    buildEventClients -= wsClient
+  }
 
   def evalCommand(config: Config, serverLog: Log)(
     wsServer: WsServer,
@@ -111,9 +148,14 @@ object Server {
     command: WsCommand
   ): Unit = {
     import config.build.tmpfs
+    import config.cli.progress
 
-    val clientLog =
-      new Log(wsClient.send, identity, serverLog.level, serverLog.unicode)
+    val clientLog = new Log(
+      message => if (wsClient.isOpen) wsClient.send(message + "\n"),
+      identity,
+      serverLog.level,
+      serverLog.unicode
+    )
     command match {
       case WsCommand.BuildEvents => buildEventClients += wsClient
       case WsCommand.Build(buildPath, targets) =>
@@ -123,15 +165,31 @@ object Server {
           targets,
           watch = false,
           tmpfs,
+          progress,
           clientLog,
-          build => onStdOut(wsServer, wsClient, build, serverLog)
+          onStdOut(wsClient),
+          onBroadcastBuildEvent(wsServer, serverLog)
         ) match {
           case Left(errors) =>
             errors.foreach(clientLog.error)
             wsClient.close()
-          case Right(uio) =>
-            // TODO Send success state to client too
-            RTS.unsafeRunAsync(uio)(_ => wsClient.close())
+          case Right(uio) => runCommandUio(uio, wsClient)
+        }
+      case WsCommand.Run(buildPath, modules) =>
+        seed.cli.Run.run(
+          buildPath,
+          modules,
+          watch = false,
+          tmpfs,
+          progress,
+          clientLog,
+          onStdOut(wsClient),
+          onBroadcastBuildEvent(wsServer, serverLog)
+        ) match {
+          case Left(errors) =>
+            errors.foreach(clientLog.error)
+            wsClient.close()
+          case Right(uio) => runCommandUio(uio, wsClient)
         }
       case WsCommand.Link(buildPath, modules, optimise) =>
         seed.cli.Link.link(
@@ -140,13 +198,15 @@ object Server {
           optimise = optimise,
           watch = false,
           tmpfs,
+          progress,
           clientLog,
-          build => onStdOut(wsServer, wsClient, build, serverLog)
+          onStdOut(wsClient),
+          onBroadcastBuildEvent(wsServer, serverLog)
         ) match {
           case Left(errors) =>
             errors.foreach(clientLog.error)
             wsClient.close()
-          case Right(uio) => RTS.unsafeRunAsync(uio)(_ => wsClient.close())
+          case Right(uio) => runCommandUio(uio, wsClient)
         }
     }
   }

--- a/src/main/scala/seed/cli/util/Ansi.scala
+++ b/src/main/scala/seed/cli/util/Ansi.scala
@@ -34,8 +34,10 @@ object ColourScheme {
 }
 
 object Ansi {
-  def esc(str: String*)  = "\u001b[" + str.mkString(";")
-  def escM(str: String*) = "\u001b[" + str.mkString(";") + "m"
+  val Escape = "\u001b["
+
+  def esc(str: String*)  = Escape + str.mkString(";")
+  def escM(str: String*) = Escape + str.mkString(";") + "m"
 
   def foreground(colour: Colour)(text: String): String =
     escM("38", "2", colour.r.toString, colour.g.toString, colour.b.toString) + text + escM(

--- a/src/main/scala/seed/cli/util/ConsoleOutput.scala
+++ b/src/main/scala/seed/cli/util/ConsoleOutput.scala
@@ -1,0 +1,67 @@
+package seed.cli.util
+
+import seed.Log
+
+class ConsoleOutput(parentLog: Log, print: String => Unit) {
+  val log = new Log(
+    l => write(l + "\n", sticky = false),
+    identity,
+    parentLog.level,
+    parentLog.unicode
+  )
+
+  private var stickyLines = 0
+  private var clearLines  = 0
+  private var flushed     = false
+
+  def isFlushed: Boolean = flushed
+
+  def processLines(output: String): String =
+    output.flatMap {
+      case '\n' if clearLines != 0 =>
+        clearLines -= 1
+
+        // Clear until end of line
+        Ansi.Escape + "0K" + "\n"
+
+      case c => c.toString
+    }
+
+  def write(output: String, sticky: Boolean = false): Unit = {
+    require(output.endsWith("\n"))
+
+    if (sticky) {
+      require(!flushed)
+      val lines = output.count(_ == '\n')
+      require(stickyLines == 0 || stickyLines == lines)
+
+      if (stickyLines == 0) {
+        stickyLines = lines
+        print(output)
+      } else {
+        // Move up
+        print(Ansi.Escape + s"${stickyLines}A" + processLines(output))
+      }
+    } else {
+      if (stickyLines > 0) {
+        clearLines = stickyLines
+        print(Ansi.Escape + s"${stickyLines}A" + processLines(output))
+        stickyLines = 0
+      } else {
+        print(processLines(output))
+      }
+    }
+  }
+
+  def flushSticky(): Unit = {
+    stickyLines = 0
+    clearLines = 0
+    flushed = true
+  }
+
+  def reset(): Unit = {
+    stickyLines = 0
+    clearLines = 0
+    flushed = false
+  }
+}

--- a/src/main/scala/seed/cli/util/ProgressBar.scala
+++ b/src/main/scala/seed/cli/util/ProgressBar.scala
@@ -1,0 +1,80 @@
+package seed.cli.util
+
+/**
+  * Ported from https://github.com/alexcrichton/cargo-fancy/blob/master/src/main.rs
+  */
+object ProgressBar {
+  val icons = List("⡆", "⠇", "⠋", "⠙", "⠸", "⢰", "⣠", "⣄")
+
+  sealed trait Result
+  object Result {
+    case object Waiting    extends Result
+    case object InProgress extends Result
+    case object Success    extends Result
+    case object Warnings   extends Result
+    case object Failure    extends Result
+  }
+
+  case class Line(
+    tick: Int,
+    result: Result,
+    name: String,
+    step: Int,
+    total: Int
+  )
+
+  val pbPartChars = Array("░", "▏", "▎", "▍", "▌", "▋", "▊", "▉")
+
+  // From https://mike42.me/blog/2018-06-make-better-cli-progress-bars-with-unicode-block-characters
+  def progressBarString(progress: Double, width: Int): String = {
+    val wholeWidth     = (progress * width).toInt
+    val remainderWidth = (progress * width) % 1
+    val partWidth      = (remainderWidth * pbPartChars.length.toDouble).toInt
+    val partChar =
+      if (width - wholeWidth - 1 < 0) "" else pbPartChars(partWidth)
+    "█" * wholeWidth + partChar + "░" * (width - wholeWidth - 1)
+  }
+
+  def render(
+    sb: StringBuilder,
+    line: Line,
+    nameLength: Int,
+    width: Int
+  ): Unit = {
+    line.result match {
+      case Result.InProgress =>
+        val icon = icons(line.tick % icons.length)
+        sb.append(ColourScheme.blue1.toFansi(s" [$icon] "))
+      case Result.Success =>
+        sb.append(ColourScheme.green1.toFansi(" [✓] "))
+      case Result.Warnings =>
+        sb.append(ColourScheme.yellow2.toFansi(" [⚠] "))
+      case Result.Failure =>
+        sb.append(ColourScheme.red1.toFansi(" [✗] "))
+      case Result.Waiting =>
+        sb.append(ColourScheme.yellow1.toFansi(" [⠿] "))
+    }
+
+    sb.append(line.name + (" " * (nameLength - line.name.length)) + " [")
+
+    val remaining = width - (3 + 2 + nameLength + 3)
+
+    val progress = if (line.total == 0) 0 else line.step.toDouble / line.total
+    sb.append(progressBarString(progress, remaining))
+
+    sb.append("]")
+  }
+
+  def printAll(progress: collection.Seq[(String, Line)]): String = {
+    val sb         = new StringBuilder
+    val nameLength = progress.map(_._2.name.length).max
+
+    progress.foreach {
+      case (_, line) =>
+        render(sb, line, nameLength, 80)
+        sb.append("\n")
+    }
+
+    sb.toString
+  }
+}

--- a/src/main/scala/seed/cli/util/Watcher.scala
+++ b/src/main/scala/seed/cli/util/Watcher.scala
@@ -1,0 +1,97 @@
+package seed.cli.util
+
+import java.nio.file.{Files, Path, StandardWatchEventKinds, WatchEvent}
+
+import org.slf4j.LoggerFactory
+import zio._
+import zio.stream._
+import io.methvin.watcher.DirectoryChangeEvent
+import io.methvin.watcher.DirectoryChangeEvent.EventType
+import io.methvin.watcher.DirectoryChangeListener
+import io.methvin.watcher.DirectoryWatcher
+import io.methvin.watcher.hashing.FileHasher
+import org.apache.commons.io.FilenameUtils
+import org.slf4j.Logger
+
+import scala.collection.JavaConverters
+import scala.concurrent.ExecutionContext
+
+object Watcher {
+  val Extensions = Array("scala", "java")
+
+  // System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE")
+
+  def watchPaths(
+    paths: List[Path],
+    onStarted: () => Unit = () => ()
+  ): Stream[Throwable, Unit] =
+    Stream.effectAsyncM[Throwable, Unit] { e =>
+      val logger = LoggerFactory.getLogger("watcher")
+      val (p, f) = paths.partition(Files.isDirectory(_))
+      val watcher = new CustomRecursiveFileMonitor(p, f, logger = logger) {
+        override def onCreate(file: Path, count: Int): Unit =
+          if (Extensions.contains(FilenameUtils.getExtension(file.toString)))
+            e(Task.succeed(()))
+        override def onModify(file: Path, count: Int): Unit =
+          if (Extensions.contains(FilenameUtils.getExtension(file.toString)))
+            e(Task.succeed(()))
+        override def onDelete(file: Path, count: Int): Unit = {}
+      }
+
+      Task.descriptorWith { d =>
+        val ec = d.executor.asEC
+        UIO {
+          watcher.start()(ec)
+          onStarted()
+        }.onTermination(_ => UIO(watcher.close()))
+      }
+    }
+}
+
+/**
+  * Adapted from https://github.com/gmethvin/directory-watcher/
+  *
+  * Original class: io.methvin.better.files.RecursiveFileMonitor
+  */
+abstract class CustomRecursiveFileMonitor(
+  val paths: List[Path],
+  val files: List[Path],
+  val fileHasher: Option[FileHasher] = Some(FileHasher.DEFAULT_FILE_HASHER),
+  val logger: Logger
+) {
+  protected[this] val watcher: DirectoryWatcher = DirectoryWatcher.builder
+    .paths(JavaConverters.seqAsJavaListConverter(paths).asJava)
+    .files(JavaConverters.seqAsJavaListConverter(files).asJava)
+    .listener(new DirectoryChangeListener {
+      override def onEvent(event: DirectoryChangeEvent): Unit =
+        event.eventType match {
+          case EventType.OVERFLOW =>
+          case et =>
+            CustomRecursiveFileMonitor.this.onEvent(
+              et.getWatchEventKind.asInstanceOf[WatchEvent.Kind[Path]],
+              event.path,
+              event.count
+            )
+        }
+      override def onException(e: Exception): Unit = e.printStackTrace()
+    })
+    .fileHasher(fileHasher.orNull)
+    .logger(logger)
+    .build()
+
+  def onEvent(eventType: WatchEvent.Kind[Path], file: Path, count: Int): Unit =
+    eventType match {
+      case StandardWatchEventKinds.ENTRY_CREATE => onCreate(file, count)
+      case StandardWatchEventKinds.ENTRY_MODIFY => onModify(file, count)
+      case StandardWatchEventKinds.ENTRY_DELETE => onDelete(file, count)
+    }
+
+  def start()(implicit executionContext: ExecutionContext): Unit =
+    executionContext.execute(() => watcher.watch())
+
+  def close(): Unit = watcher.close()
+
+  def onCreate(file: Path, count: Int): Unit
+  def onModify(file: Path, count: Int): Unit
+  def onDelete(file: Path, count: Int): Unit
+}

--- a/src/main/scala/seed/cli/util/WsClient.scala
+++ b/src/main/scala/seed/cli/util/WsClient.scala
@@ -15,7 +15,7 @@ class WsClient(serverUri: URI, payload: () => String, log: Log)
   }
   override def onClose(code: Int, reason: String, remote: Boolean): Unit =
     log.debug("Connection closed")
-  override def onMessage(message: String): Unit     = println(message)
+  override def onMessage(message: String): Unit     = print(message)
   override def onMessage(message: ByteBuffer): Unit = {}
   override def onError(ex: Exception): Unit =
     log.error(s"An error occurred: $ex")

--- a/src/main/scala/seed/cli/util/WsServer.scala
+++ b/src/main/scala/seed/cli/util/WsServer.scala
@@ -20,8 +20,9 @@ class WsServer(
 ) extends WebSocketServer(address) {
   setReuseAddr(true)
 
-  def clientIp(conn: WebSocket): String =
-    conn.getRemoteSocketAddress.getAddress.getHostAddress
+  private def clientIp(conn: WebSocket): String =
+    if (conn.getRemoteSocketAddress == null) "<unknown>"
+    else conn.getRemoteSocketAddress.getAddress.getHostAddress
 
   override def onOpen(conn: WebSocket, handshake: ClientHandshake): Unit =
     log.debug(s"Client ${Ansi.italic(clientIp(conn))} connected")

--- a/src/main/scala/seed/generation/util/PathUtil.scala
+++ b/src/main/scala/seed/generation/util/PathUtil.scala
@@ -1,11 +1,14 @@
 package seed.generation.util
 
 import java.nio.file.{Files, Path, Paths}
+import java.security.AccessController
 
 import seed.Log
 import seed.cli.util.Ansi
 
 object PathUtil {
+  val TemporaryFolder = Paths.get(System.getProperty("java.io.tmpdir"))
+
   def tmpfsPath(projectPath: Path, log: Log): Path = {
     val name = projectPath.toAbsolutePath.getFileName.toString
     log.info("Build path set to tmpfs")

--- a/src/main/scala/seed/model/BuildEvent.scala
+++ b/src/main/scala/seed/model/BuildEvent.scala
@@ -8,8 +8,9 @@ object BuildEvent {
       extends BuildEvent("compiled")
   case class Compiling(module: String, platform: Platform)
       extends BuildEvent("compiling")
-  case class Failed(module: String) extends BuildEvent("failed")
-  case class Linked(path: String)   extends BuildEvent("linked")
+  case class Failed(module: String, platform: Platform)
+      extends BuildEvent("failed")
+  case class Linked(path: String) extends BuildEvent("linked")
 
   implicit val encodeBuildEvent: Encoder[BuildEvent] = be =>
     Json.fromFields(
@@ -25,7 +26,11 @@ object BuildEvent {
               "module"   -> Json.fromString(module),
               "platform" -> Json.fromString(platform.id)
             )
-          case Failed(module) => List("module" -> Json.fromString(module))
+          case Failed(module, platform) =>
+            List(
+              "module"   -> Json.fromString(module),
+              "platform" -> Json.fromString(platform.id)
+            )
           case Linked(path) =>
             List("path" -> Json.fromString(path))
         })

--- a/src/main/scala/seed/model/Config.scala
+++ b/src/main/scala/seed/model/Config.scala
@@ -12,7 +12,11 @@ case class Config(
 )
 
 object Config {
-  case class Cli(level: LogLevel = LogLevel.Debug, unicode: Boolean = true)
+  case class Cli(
+    level: LogLevel = LogLevel.Debug,
+    unicode: Boolean = true,
+    progress: Boolean = true
+  )
   case class Build(tmpfs: Boolean = false)
   case class Resolution(
     silent: Boolean = false,

--- a/src/test/scala/seed/cli/util/WatcherSpec.scala
+++ b/src/test/scala/seed/cli/util/WatcherSpec.scala
@@ -1,0 +1,88 @@
+package seed.cli.util
+
+import java.nio.file.Files
+
+import minitest.SimpleTestSuite
+import org.apache.commons.io.FileUtils
+import seed.generation.util.BuildUtil
+import zio.IO
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object WatcherSpec extends SimpleTestSuite {
+  testAsync("Detect new file in root path") {
+    val rootPath = BuildUtil.tempPath.resolve("watcher")
+    Files.createDirectories(rootPath)
+
+    val collected = mutable.ListBuffer[Unit]()
+    var stop      = false
+
+    val watcher = Watcher
+      .watchPaths(
+        List(rootPath),
+        () => {
+          // Only consider Scala/Java source files
+          FileUtils.write(rootPath.resolve("test.html").toFile, "test", "UTF-8")
+          stop = true
+          FileUtils
+            .write(rootPath.resolve("test.scala").toFile, "test", "UTF-8")
+        }
+      )
+      .foreachWhile { v =>
+        IO.effectTotal {
+          collected += v
+          !stop
+        }
+      }
+
+    RTS.unsafeRunToFuture(watcher).map(_ => assertEquals(collected, List(())))
+  }
+
+  testAsync("Detect new file in sub-directory") {
+    val rootPath         = BuildUtil.tempPath.resolve("watcher2")
+    val subDirectoryPath = rootPath.resolve("sub")
+    Files.createDirectories(subDirectoryPath)
+
+    val collected = mutable.ListBuffer[Unit]()
+    var stop      = false
+
+    val watcher = Watcher
+      .watchPaths(List(rootPath), { () =>
+        stop = true
+        FileUtils.write(rootPath.resolve("test.scala").toFile, "test", "UTF-8")
+      })
+      .foreachWhile { v =>
+        IO.effectTotal {
+          collected += v
+          !stop
+        }
+      }
+
+    RTS.unsafeRunToFuture(watcher).map(_ => assertEquals(collected, List(())))
+  }
+
+  testAsync("Watch file path") {
+    val rootPath = BuildUtil.tempPath.resolve("watcher3")
+    Files.createDirectories(rootPath)
+    val filePath = rootPath.resolve("test.scala")
+    FileUtils.write(filePath.toFile, "test", "UTF-8")
+
+    val collected = mutable.ListBuffer[Unit]()
+    var stop      = false
+
+    val watcher = Watcher
+      .watchPaths(List(filePath), { () =>
+        stop = true
+        FileUtils.write(filePath.toFile, "test2", "UTF-8")
+      })
+      .foreachWhile { v =>
+        IO.effectTotal {
+          collected += v
+          !stop
+        }
+      }
+
+    RTS.unsafeRunToFuture(watcher).map(_ => assertEquals(collected, List(())))
+  }
+}

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -297,8 +297,10 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
       List("demo"),
       watch = false,
       tmpfs = false,
+      progress = false,
       if (expectFailure) Log.silent else Log.urgent,
-      _ => _ => ()
+      _ => (),
+      _ => ()
     )
 
     val uio = result.right.get
@@ -342,6 +344,10 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
   testAsync("Build project with failing custom command target") { _ =>
     buildCustomTarget("custom-command-target-fail", expectFailure = true)
+  }
+
+  testAsync("Build project with failing compilation") { _ =>
+    buildCustomTarget("compilation-failure", expectFailure = true)
   }
 
   testAsync("Generate non-JVM project") { _ =>

--- a/src/test/scala/seed/generation/IdeaSpec.scala
+++ b/src/test/scala/seed/generation/IdeaSpec.scala
@@ -169,7 +169,7 @@ object IdeaSpec extends SimpleTestSuite {
       .byTagAll["orderEntry"]
       .filter(_.attr("type").contains("module"))
       .flatMap(_.attr("module-name"))
-    assertEquals(moduleNames, List("core", "base"))
+    assertEquals(moduleNames, List("base", "core"))
   }
 
   test("Generate non-JVM cross-platform module") {

--- a/src/test/scala/seed/generation/PackageSpec.scala
+++ b/src/test/scala/seed/generation/PackageSpec.scala
@@ -43,18 +43,7 @@ object PackageSpec extends TestSuite[Unit] {
       Log.urgent
     )
 
-    val result = seed.cli.Build.build(
-      path,
-      Some(outputPath),
-      List("app"),
-      watch = false,
-      tmpfs = false,
-      Log.urgent,
-      _ => _ => ()
-    )
-
     for {
-      _ <- RTS.unsafeRunToFuture(result.right.get)
       result <- {
         cli.Package.ui(
           Config(),
@@ -64,6 +53,7 @@ object PackageSpec extends TestSuite[Unit] {
           "app",
           Some(buildPath),
           libs = true,
+          progress = false,
           packageConfig,
           Log.urgent
         )

--- a/src/test/scala/seed/generation/util/TestProcessHelper.scala
+++ b/src/test/scala/seed/generation/util/TestProcessHelper.scala
@@ -28,7 +28,7 @@ object TestProcessHelper {
 
   def runCommand(cwd: Path, cmd: List[String]): Future[String] = {
     val sb = new StringBuilder
-    val process = ProcessHelper.runCommmand(
+    val process = ProcessHelper.runCommand(
       cwd,
       cmd,
       None,

--- a/test/compilation-failure/build.toml
+++ b/test/compilation-failure/build.toml
@@ -1,0 +1,5 @@
+[project]
+scalaVersion = "2.13.0"
+
+[module.demo.jvm]
+sources = ["demo"]

--- a/test/compilation-failure/demo/Main.scala
+++ b/test/compilation-failure/demo/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = invalidIdentifier
+}


### PR DESCRIPTION
Build and run modules with the Build Server Protocol (BSP).
Previously, we were using Bloop's CLI which has the following
limitations:

- `bloop run --watch` does not compile the changed sources if the
  process is running already:
  https://github.com/scalacenter/bloop/issues/558
- For each Bloop build, only a single command can be run at a time:
  https://github.com/scalacenter/bloop/issues/982
- No detailed build progress information is available

Using BSP allows us to integrate more tightly with Bloop and avoid
these limitations. When the user now executes a Seed command, the
following steps are performed:

First, `bloop bsp` is run which will start a BSP server in the
background and listen on a UNIX socket. Then, bsp4j is used to
establish a connection using ZIO's exponential retry policy. Once
the connection is active, the corresponding BSP tasks are executed
sequentially. The BSP server responds asynchronously with the
results of the running tasks (e.g. compilation diagnostics or
progress updates). Finally, the BSP server can be gracefully shut
down and the socket file removed.

BSP reports detailed information on the compilation progress which
allows us to render a separate progress bar for each module.
Compilation messages (warnings or errors) do not interfere with the
progress bar since messages are printed above it. Progress bars are
disabled in the Docker image to avoid verbose CI logs.

A new command for running modules was introduced, called `run`. It
is currently limited to one module since programs can be
non-terminating.

The `package` command now builds the supplied module prior to
packaging it. This change was needed since BSP uses a different
target path for class files compared to Bloop's CLI command.

The `link` command continues to use the Bloop CLI since this
operation is not exposed via BSP yet.

A bug was fixed in `server` that resulted in the `optimise`
parameter being ignored when sending a link request.

The commands `build`, `run` and `link` support a watch mode that can
be enabled by passing in `--watch`. It was implemented based on
EPFL's fork of the directory-watcher library which supports watching
file paths. The watch events are then exposed as a ZIO stream.

With these changes, the user can run operations in parallel on
multiple modules defined in the same build. We can also
automatically restart JVM processes whenever source files are
changed. As an example, this enables the following workflow for a
client/server application:

```bash
seed link client --watch  # Terminal 1: Link Scala.js frontend
seed run server --watch   # Terminal 2: Run Scala JVM backend
```

Closes #58.