### PR TITLE
Scaffold: Set correct root path when only one platform was selected

### DIFF
--- a/src/main/scala/seed/cli/Scaffold.scala
+++ b/src/main/scala/seed/cli/Scaffold.scala
@@ -594,7 +594,7 @@ class Scaffold(log: Log, silent: Boolean = false) {
     (if (scalaJsVersion.isEmpty) List() else List(
       NamedTable(
         List("module", moduleName, "js"),
-        Map("root" -> Str("js")) ++
+        Map("root" -> (if (platforms.size == 1) Str(".") else Str("js"))) ++
         (if (
           jsScalaVersion.isDefined && !jsScalaVersion.contains(jvmScalaVersion)
          ) Map("scalaVersion" -> Str(jsScalaVersion.get)) else Map()
@@ -622,7 +622,7 @@ class Scaffold(log: Log, silent: Boolean = false) {
       NamedTable(
         List("module", moduleName, "jvm"),
         Map(
-          "root" -> Str("jvm"),
+          "root" -> (if (platforms.size == 1) Str(".") else Str("jvm")),
           "sources" -> Arr(List(
             if (platforms.size == 1) Str("src") else Str("jvm/src")
           ))
@@ -644,7 +644,7 @@ class Scaffold(log: Log, silent: Boolean = false) {
     (if (scalaNativeVersion.isEmpty) List() else List(
       NamedTable(
         List("module", moduleName, "native"),
-        Map("root" -> Str("native")) ++
+        Map("root" -> (if (platforms.size == 1) Str(".") else Str("native"))) ++
         (if (
           nativeScalaVersion.isDefined &&
           !nativeScalaVersion.contains(jvmScalaVersion)

--- a/src/test/scala/seed/cli/ScaffoldSpec.scala
+++ b/src/test/scala/seed/cli/ScaffoldSpec.scala
@@ -4,12 +4,12 @@ import minitest.SimpleTestSuite
 import seed.Log
 import seed.model.{Organisation, Platform}
 import toml.Node.NamedTable
-import toml.Value.Str
+import toml.Value.{Arr, Str}
 
 object ScaffoldSpec extends SimpleTestSuite {
   private val scaffold = new Scaffold(Log.urgent, silent = true)
 
-  test("Create build file one non-JVM platform") {
+  test("Create build file for one non-JVM platform") {
     val result = scaffold.generateBuildFile(
       "example",
       stable = true,
@@ -27,6 +27,10 @@ object ScaffoldSpec extends SimpleTestSuite {
 
     val module = result.nodes(1).asInstanceOf[NamedTable]
     assertEquals(module.ref, List("module", "example", "native"))
+    assertEquals(
+      module.values,
+      Map("root" -> Str("."), "sources" -> Arr(List(Str("src"))))
+    )
 
     assertEquals(result.nodes.length, 2)
   }


### PR DESCRIPTION
The folders `js/`, `jvm/` and `native/` only exist when multiple
platforms were chosen. Otherwise, the sources go to `src/`.
Therefore, the IDEA root path must be set to the current working
directory.