### PR TITLE
MavenCentral: Fix resolution of Scala.js 1.0 artefacts

### DIFF
--- a/src/main/scala/seed/generation/util/ScalaCompiler.scala
+++ b/src/main/scala/seed/generation/util/ScalaCompiler.scala
@@ -9,7 +9,7 @@ import seed.artefact.ArtefactResolution.CompilerResolution
 import seed.config.BuildConfig.Build
 import seed.model.Build.Module
 import seed.model.Platform.{JavaScript, Native}
-import seed.model.{Artefact, Build, Platform}
+import seed.model.{Artefact, Platform}
 
 object ScalaCompiler {
   private def resolveCompiler(

--- a/src/test/scala/seed/artefact/MavenCentralSpec.scala
+++ b/src/test/scala/seed/artefact/MavenCentralSpec.scala
@@ -3,6 +3,8 @@ package seed.artefact
 import minitest.SimpleTestSuite
 import seed.model.Platform.JVM
 import seed.Log
+import seed.model.Build.VersionTag
+import seed.model.Platform
 
 object MavenCentralSpec extends SimpleTestSuite {
   test("Parse library artefact versions") {
@@ -39,5 +41,34 @@ object MavenCentralSpec extends SimpleTestSuite {
       parse(stable = true),
       List((JVM, "2.11", "2.11"), (JVM, "2.12", "2.12"), (JVM, "2.13", "2.13"))
     )
+  }
+
+  test("Format Scala.js artefact names") {
+    val sjs06 = MavenCentral.formatArtefactName(
+      "slinky-core",
+      VersionTag.PlatformBinary,
+      Platform.JavaScript,
+      "0.6.32",
+      "2.13.1"
+    )
+    assertEquals(sjs06, "slinky-core_sjs0.6_2.13")
+
+    val sjs10rc2 = MavenCentral.formatArtefactName(
+      "slinky-core",
+      VersionTag.PlatformBinary,
+      Platform.JavaScript,
+      "1.0-RC2",
+      "2.13.1"
+    )
+    assertEquals(sjs10rc2, "slinky-core_sjs1.0-RC2_2.13")
+
+    val sjs10 = MavenCentral.formatArtefactName(
+      "slinky-core",
+      VersionTag.PlatformBinary,
+      Platform.JavaScript,
+      "1.0.1",
+      "2.13.1"
+    )
+    assertEquals(sjs10, "slinky-core_sjs1_2.13")
   }
 }


### PR DESCRIPTION
From v1.0 onwards, the binary tag does not contain the minor version
anymore.

Closes #91.