### PR TITLE
Publish: Use absolute path when determining Git version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,9 @@ steps:
   - name: test
     image: alpine:3.10
     commands:
-      - apk add --no-cache openjdk8 python curl nodejs clang libc-dev libunwind-dev g++
+      - apk add --no-cache openjdk8 python curl nodejs clang libc-dev libunwind-dev g++ git
+      - git config --global user.email "ci@example.com"
+      - git config --global user.name "CI user"
       - curl -L https://github.com/scalacenter/bloop/releases/download/v$(cat BLOOP)/install.py | python - -d bloop
       - export PATH=$(pwd)/bloop:$PATH
       - blp-server &

--- a/src/main/scala/seed/cli/Publish.scala
+++ b/src/main/scala/seed/cli/Publish.scala
@@ -414,7 +414,9 @@ object Publish {
         log.info("Determining version from Git tag...")
         import sys.process._
         val result =
-          Try(Process("git describe --tags", projectPath.toFile).!!).toOption
+          Try(
+            Process("git describe --tags", projectPath.toAbsolutePath.toFile).!!
+          ).toOption
             .map { t =>
               val tag = t.trim
               if (!tag.startsWith("v")) tag else tag.tail

--- a/src/test/scala/seed/cli/PublishSpec.scala
+++ b/src/test/scala/seed/cli/PublishSpec.scala
@@ -1,0 +1,52 @@
+package seed.cli
+
+import java.io.File
+import java.nio.file.{Files, Path}
+
+import minitest.SimpleTestSuite
+import org.apache.commons.io.FileUtils
+import seed.Log
+import seed.generation.util.BuildUtil
+
+import sys.process._
+
+object PublishSpec extends SimpleTestSuite {
+  def testVersionDetection(path: File): Unit = {
+    Process("git init", path).!!
+
+    FileUtils.write(new File(path, "test.txt"), "test", "UTF-8")
+    Process("git add test.txt", path).!!
+    Process("git commit . -m import", path).!!
+    Process("git tag 0.1.0", path).!! // no 'v' prefix
+    assertEquals(
+      Publish.getVersion(path.toPath, None, Log.silent),
+      Some("0.1.0")
+    )
+
+    FileUtils.write(new File(path, "test2.txt"), "test", "UTF-8")
+    Process("git add test2.txt", path).!!
+    Process("git commit . -m import", path).!!
+    Process("git tag v0.1.1", path).!! // 'v' prefix
+    assertEquals(
+      Publish.getVersion(path.toPath, None, Log.silent),
+      Some("0.1.1")
+    )
+  }
+
+  test("Determine version number (relative path)") {
+    val relativePath = new File("temp-git-version")
+    if (Files.exists(relativePath.toPath))
+      FileUtils.deleteDirectory(relativePath)
+    Files.createDirectories(relativePath.toPath)
+    testVersionDetection(relativePath)
+    FileUtils.deleteDirectory(relativePath)
+  }
+
+  test("Determine version number (absolute path)") {
+    val relativePath = BuildUtil.tempPath.resolve("git-version")
+    if (Files.exists(relativePath))
+      FileUtils.deleteDirectory(relativePath.toFile)
+    Files.createDirectories(relativePath)
+    testVersionDetection(relativePath.toFile)
+  }
+}


### PR DESCRIPTION
The Git command execution might fail if relative paths are used.