### PR TITLE
ArtefactResolution: Fix inheritance on test modules

### DIFF
--- a/src/main/scala/seed/artefact/ArtefactResolution.scala
+++ b/src/main/scala/seed/artefact/ArtefactResolution.scala
@@ -215,8 +215,12 @@ object ArtefactResolution {
     platform: Platform,
     tpe: Type
   ): Set[JavaDep] = {
-    val m  = build(name).module
-    val pm = BuildConfig.platformModule(m, platform).get
+    val baseModule = build(name).module
+    val m =
+      if (tpe == Regular) baseModule
+      else baseModule.test.getOrElse(baseModule)
+    val pm = BuildConfig.platformModule(m, platform).getOrElse(m)
+
     val modules = BuildConfig
       .collectModuleDeps(
         build,
@@ -225,7 +229,7 @@ object ArtefactResolution {
         Set(platform)
       )
       .map(m => build(m).module)
-      .toSet ++ Set(m)
+      .toSet ++ Set(baseModule)
 
     if (tpe == Test)
       modules.flatMap(

--- a/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
+++ b/src/test/scala/seed/artefact/ArtefactResolutionSpec.scala
@@ -130,6 +130,35 @@ object ArtefactResolutionSpec extends SimpleTestSuite {
     )
   }
 
+  test("Derive runtime libraries from test module (3)") {
+    // Child module should inherit libraries of parent module
+    val path = new File("test", "test-inherit-deps")
+    val tomlBuild =
+      FileUtils.readFileToString(new File(path, "build.toml"), "UTF-8")
+    val build = BuildConfigSpec.parseBuild(tomlBuild)(_ => "")
+
+    val libs = ArtefactResolution.allRuntimeLibs(build)
+    assertEquals(
+      libs,
+      Map(
+        ("foo", JVM, Regular) -> Set(
+          JavaDep("org.scala-lang", "scala-library", "2.13.0"),
+          JavaDep("org.scala-lang", "scala-reflect", "2.13.0")
+        ),
+        ("foo", JVM, Test) -> Set(
+          JavaDep("org.scalatest", "scalatest_2.13", "3.0.8")
+        ),
+        ("bar", JVM, Regular) -> Set(
+          JavaDep("org.scala-lang", "scala-library", "2.13.0"),
+          JavaDep("org.scala-lang", "scala-reflect", "2.13.0")
+        ),
+        ("bar", JVM, Test) -> Set(
+          JavaDep("org.scalatest", "scalatest_2.13", "3.0.8")
+        )
+      )
+    )
+  }
+
   test("jvmDeps()") {
     val module = Module(
       scalaVersion = Some("2.12.8"),

--- a/src/test/scala/seed/generation/GenerateSpec.scala
+++ b/src/test/scala/seed/generation/GenerateSpec.scala
@@ -1,0 +1,32 @@
+package seed.generation
+
+import java.nio.file.{Files, Paths}
+
+import minitest.SimpleTestSuite
+import seed.Cli.Command
+import seed.{Log, cli}
+import seed.config.BuildConfig
+import seed.generation.BloopIntegrationSpec.packageConfig
+import seed.generation.util.BuildUtil.tempPath
+import seed.model.Config
+
+object GenerateSpec extends SimpleTestSuite {
+  test("Inherit scalaDeps in test module") {
+    val config = BuildConfig
+      .load(Paths.get("test", "test-inherit-deps"), Log.urgent)
+      .get
+    import config._
+    val buildPath = tempPath.resolve("test-inherit-deps-generate")
+
+    Files.createDirectory(buildPath)
+    cli.Generate.ui(
+      Config(),
+      projectPath,
+      buildPath,
+      resolvers,
+      build,
+      Command.Bloop(packageConfig),
+      Log.urgent
+    )
+  }
+}

--- a/test/test-inherit-deps/build.toml
+++ b/test/test-inherit-deps/build.toml
@@ -1,0 +1,17 @@
+[project]
+scalaVersion = "2.13.0"
+
+[module.foo.jvm]
+sources = ["foo/src"]
+
+[module.foo.test.jvm]
+sources   = ["foo/test"]
+scalaDeps = [["org.scalatest", "scalatest", "3.0.8"]]
+
+[module.bar.jvm]
+sources = ["bar/src"]
+
+# Should inherit scalaDeps from [module.foo.test.jvm]
+[module.bar.test.jvm]
+moduleDeps = ["foo"]
+sources    = ["bar/test"]


### PR DESCRIPTION
Library dependencies defined on the referenced module should be
inherited.