### PR TITLE
Add support for Scala.js 0.6.29+ and 1.0 test modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ jsdom          = false  # Import the jsdom library in the generated.
                         # yarn/npm. Useful for test cases that rely
                         # on DOM operations.
 emitSourceMaps = true   # Emit source maps
+moduleKind     = "default"  # Options: default, commonjs
 output         = "myModule.js"  # Path to generated file
                                 # Default: <module name>.js
 ```

--- a/src/main/scala/seed/config/util/TomlUtils.scala
+++ b/src/main/scala/seed/config/util/TomlUtils.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import org.apache.commons.io.FileUtils
 import seed.{Log, LogLevel}
 import seed.cli.util.Ansi
-import seed.model.Build.{PlatformModule, VersionTag}
+import seed.model.Build.{ModuleKindJs, PlatformModule, VersionTag}
 import seed.model.{Licence, Platform, TomlBuild}
 import toml.{Codec, Value}
 
@@ -68,6 +68,18 @@ object TomlUtils {
 
       case (value, _, _) =>
         Left((List(), s"Version tag expected, $value provided"))
+    }
+
+    implicit val moduleKindJs: Codec[ModuleKindJs] = Codec {
+      case (Value.Str(id), _, _) =>
+        id match {
+          case "default"  => Right(ModuleKindJs.Default)
+          case "commonjs" => Right(ModuleKindJs.CommonJs)
+          case _          => Left((List(), "Invalid module kind provided"))
+        }
+
+      case (value, _, _) =>
+        Left((List(), s"Module kind expected, $value provided"))
     }
 
     implicit val licenceCodec: Codec[Licence] = Codec {

--- a/src/main/scala/seed/model/Artefact.scala
+++ b/src/main/scala/seed/model/Artefact.scala
@@ -29,6 +29,8 @@ object Artefact {
 
   val ScalaJsCompiler = Artefact("org.scala-js", "scalajs-compiler", Some(Full))
   val ScalaJsLibrary  = Artefact("org.scala-js", "scalajs-library", Some(Binary))
+  val ScalaJsTestBridge =
+    Artefact("org.scala-js", "scalajs-test-bridge", Some(Binary))
 
   val ScalaNativePlugin = Artefact("org.scala-native", "nscplugin", Some(Full))
   val ScalaNativeJavalib =

--- a/src/main/scala/seed/model/Build.scala
+++ b/src/main/scala/seed/model/Build.scala
@@ -98,6 +98,12 @@ object Build {
       )
   }
 
+  sealed trait ModuleKindJs
+  object ModuleKindJs {
+    case object Default  extends ModuleKindJs
+    case object CommonJs extends ModuleKindJs
+  }
+
   // TODO Instead of using this `case class` directly, create a polymorphic
   //      version for different platform types
   case class Module(
@@ -122,6 +128,7 @@ object Build {
     // --- JavaScript
     jsdom: Boolean = false,
     emitSourceMaps: Boolean = true,
+    moduleKind: ModuleKindJs = ModuleKindJs.Default,
     // --- Native
     gc: Option[String] = None,
     targetTriple: Option[String] = None,

--- a/src/test/scala/seed/generation/BloopIntegrationSpec.scala
+++ b/src/test/scala/seed/generation/BloopIntegrationSpec.scala
@@ -24,15 +24,6 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
   override def setup(): Unit             = ()
   override def tearDown(env: Unit): Unit = ()
 
-  def readBloopJson(path: Path): bloop.config.Config.File = {
-    val content = FileUtils.readFileToString(path.toFile, "UTF-8")
-
-    import io.circe.parser._
-    decode[bloop.config.Config.File](content)(
-      ConfigEncoderDecoders.allDecoder
-    ).right.get
-  }
-
   def compileAndRun(projectPath: Path) = {
     def compile =
       TestProcessHelper.runBloop(projectPath)("compile", "example").map { x =>
@@ -80,14 +71,14 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
     val bloopBuildPath = buildPath.resolve("build").resolve("bloop")
 
     val bloopPath = buildPath.resolve(".bloop")
-    val root      = readBloopJson(bloopPath.resolve("root.json"))
+    val root      = util.BloopUtil.readJson(bloopPath.resolve("root.json"))
     val paths     = root.project.classpath.filter(_.startsWith(buildPath))
     assertEquals(
       paths,
       List(
         bloopBuildPath.resolve("a"),
-        bloopBuildPath.resolve("b"),
-        bloopBuildPath.resolve("shared")
+        bloopBuildPath.resolve("shared"),
+        bloopBuildPath.resolve("b")
       )
     )
   }
@@ -187,10 +178,13 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
     val bloopPath = buildPath.resolve(".bloop")
 
-    val macrosJvm  = readBloopJson(bloopPath.resolve("macros-jvm.json"))
-    val macrosJs   = readBloopJson(bloopPath.resolve("macros-js.json"))
-    val exampleJvm = readBloopJson(bloopPath.resolve("example-jvm.json"))
-    val exampleJs  = readBloopJson(bloopPath.resolve("example-js.json"))
+    val macrosJvm =
+      util.BloopUtil.readJson(bloopPath.resolve("macros-jvm.json"))
+    val macrosJs = util.BloopUtil.readJson(bloopPath.resolve("macros-js.json"))
+    val exampleJvm =
+      util.BloopUtil.readJson(bloopPath.resolve("example-jvm.json"))
+    val exampleJs =
+      util.BloopUtil.readJson(bloopPath.resolve("example-js.json"))
 
     def getFileName(path: String): String = path.drop(path.lastIndexOf('/') + 1)
 
@@ -337,7 +331,7 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
         .resolve("custom-command-target")
         .resolve(".bloop")
         .resolve("demo.json")
-      val result = readBloopJson(path)
+      val result = util.BloopUtil.readJson(path)
 
       // Do not include the `utils` classpath since the module is only a custom
       // build target and does not have a JVM target.
@@ -412,14 +406,14 @@ object BloopIntegrationSpec extends TestSuite[Unit] {
 
     val bloopPath = buildPath.resolve(".bloop")
 
-    val root  = readBloopJson(bloopPath.resolve("example.json"))
+    val root  = util.BloopUtil.readJson(bloopPath.resolve("example.json"))
     val paths = root.project.classpath.filter(_.startsWith(buildPath))
 
     assertEquals(
       paths,
       List(
-        bloopBuildPath.resolve("base"),
-        bloopBuildPath.resolve("core")
+        bloopBuildPath.resolve("core"),
+        bloopBuildPath.resolve("base")
       )
     )
   }

--- a/src/test/scala/seed/generation/GenerateSpec.scala
+++ b/src/test/scala/seed/generation/GenerateSpec.scala
@@ -1,16 +1,18 @@
 package seed.generation
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import minitest.SimpleTestSuite
 import seed.Cli.Command
 import seed.{Log, cli}
 import seed.config.BuildConfig
 import seed.generation.BloopIntegrationSpec.packageConfig
-import seed.generation.util.BuildUtil.tempPath
+import seed.generation.util.BuildUtil
 import seed.model.Config
 
 object GenerateSpec extends SimpleTestSuite {
+  private val tempPath = BuildUtil.tempPath.resolve("generate")
+
   test("Inherit scalaDeps in test module") {
     val config = BuildConfig
       .load(Paths.get("test", "test-inherit-deps"), Log.urgent)
@@ -18,7 +20,7 @@ object GenerateSpec extends SimpleTestSuite {
     import config._
     val buildPath = tempPath.resolve("test-inherit-deps-generate")
 
-    Files.createDirectory(buildPath)
+    Files.createDirectories(buildPath)
     cli.Generate.ui(
       Config(),
       projectPath,
@@ -27,6 +29,45 @@ object GenerateSpec extends SimpleTestSuite {
       build,
       Command.Bloop(packageConfig),
       Log.urgent
+    )
+  }
+
+  test("Generate Scala.js 1.0 test project") {
+    val config = BuildConfig
+      .load(Paths.get("test", "test-scalajs-10"), Log.urgent)
+      .get
+    import config._
+    val buildPath = tempPath.resolve("test-scalajs-10")
+
+    Files.createDirectories(buildPath)
+    cli.Generate.ui(
+      Config(),
+      projectPath,
+      buildPath,
+      resolvers,
+      build,
+      Command.Bloop(packageConfig),
+      Log.urgent
+    )
+
+    val bloopPath = buildPath.resolve(".bloop")
+
+    val root  = util.BloopUtil.readJson(bloopPath.resolve("example-test.json"))
+    val paths = root.project.classpath
+
+    def artefact(path: Path): String = path.getFileName.toString
+    assertEquals(
+      paths.map(artefact),
+      List(
+        "scala-library-2.13.2.jar",
+        "scala-reflect-2.13.2.jar",
+        "scalajs-junit-test-runtime_2.13-1.0.1.jar",
+        "munit_sjs1_2.13-0.7.4.jar",
+        "scalajs-test-interface_2.13-1.0.1.jar",
+        "scalajs-test-bridge_2.13-1.0.1.jar",
+        "scalajs-library_2.13-1.0.1.jar",
+        "example"
+      )
     )
   }
 }

--- a/src/test/scala/seed/generation/util/BloopUtil.scala
+++ b/src/test/scala/seed/generation/util/BloopUtil.scala
@@ -1,0 +1,17 @@
+package seed.generation.util
+
+import java.nio.file.Path
+
+import bloop.config.ConfigEncoderDecoders
+import org.apache.commons.io.FileUtils
+
+object BloopUtil {
+  def readJson(path: Path): bloop.config.Config.File = {
+    val content = FileUtils.readFileToString(path.toFile, "UTF-8")
+
+    import io.circe.parser._
+    decode[bloop.config.Config.File](content)(
+      ConfigEncoderDecoders.allDecoder
+    ).right.get
+  }
+}

--- a/test/test-scalajs-10/build.toml
+++ b/test/test-scalajs-10/build.toml
@@ -1,0 +1,13 @@
+[project]
+scalaVersion = "2.13.2"
+scalaJsVersion = "1.0.1"
+testFrameworks = ["munit.Framework"]
+
+[module.example.js]
+root = "."
+sources = ["src"]
+
+[module.example.test.js]
+sources = ["test"]
+scalaDeps = [["org.scalameta", "munit", "0.7.4"]]
+moduleKind = "commonjs"

--- a/test/test-scalajs-10/test/ExampleSpec.scala
+++ b/test/test-scalajs-10/test/ExampleSpec.scala
@@ -1,0 +1,5 @@
+class ExampleSpec extends munit.FunSuite {
+  test("Check") {
+    assertEquals(1, 1)
+  }
+}


### PR DESCRIPTION
For newer Scala.js versions, the `scalajs-test-bridge` artefact must be added to the classpath.

Further changes were made to improve compatibility with the MUnit testing library:

1. Add build setting allowing to specify Scala.js module kind
2. Fix ordering of classpath in generated Bloop configuration files

**See also:**
- scalacenter/bloop#1234
- scalameta/munit#114